### PR TITLE
Added features, deprecating WebDriverUtil and WebDriverToolbox, fixed…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target/
+.classpath
+.project
+.settings/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.sios.stc.coseng</groupId>
   <artifactId>coseng</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <properties>
     <coseng.version>2.0</coseng.version>
     <java.source.version>1.8</java.source.version>
@@ -177,7 +177,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven.javadoc.plugin.version}</version>
         <configuration>
-          <author>false</author>
+          <author>true</author>
           <tags>
             <tag>
               <name>version.coseng</name>

--- a/src/main/java/com/sios/stc/coseng/run/Browsers.java
+++ b/src/main/java/com/sios/stc/coseng/run/Browsers.java
@@ -25,7 +25,7 @@ import java.util.List;
  * @since 2.0
  * @version.coseng
  */
-class Browsers {
+public class Browsers {
 
     /**
      * The Enum Browser.
@@ -33,7 +33,7 @@ class Browsers {
      * @since 2.0
      * @version.coseng
      */
-    protected static enum Browser {
+    public static enum Browser {
         ALL, FIREFOX, CHROME, IE, EDGE;
     }
 

--- a/src/main/java/com/sios/stc/coseng/run/Concurrent.java
+++ b/src/main/java/com/sios/stc/coseng/run/Concurrent.java
@@ -19,6 +19,7 @@ package com.sios.stc.coseng.run;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.lang3.time.StopWatch;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.testng.ITestNGListener;
@@ -65,10 +66,12 @@ class Concurrent implements Runnable {
         Thread thread = Thread.currentThread();
         String name = test.getName();
         /* Seed runner */
-        CosengRunner.setThreadTest(thread, test);
+        CosengRunner.addThreadTest(thread, test);
         log.debug("Test [{}] thread [{}] {}]", name, thread.getId(), thread.getName());
         TestNG testNg = new TestNG();
+        StopWatch stopWatch = new StopWatch();
         try {
+            stopWatch.start();
             testNg.setXmlSuites(test.getXmlSuites());
             testNg.setVerbose(test.getVerbosity());
             testNg.setOutputDirectory(test.getReportDirectory());
@@ -83,6 +86,9 @@ class Concurrent implements Runnable {
             if (testNg.hasFailure()) {
                 test.setIsFailed(true);
             }
+            stopWatch.stop();
+            log.info("Test [{}] completed; elapsed time (hh:mm:ss:ms) [{}]", name,
+                    stopWatch.toString());
         } catch (Exception e) {
             test.setIsFailed(true);
             throw new RuntimeException("Unable to execute TestNG run for test [" + name + "]", e);

--- a/src/main/java/com/sios/stc/coseng/run/CosengRunner.java
+++ b/src/main/java/com/sios/stc/coseng/run/CosengRunner.java
@@ -16,17 +16,46 @@
  */
 package com.sios.stc.coseng.run;
 
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.time.StopWatch;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
 import org.openqa.selenium.interactions.Actions;
+import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.paulhammant.ngwebdriver.NgWebDriver;
+import com.sios.stc.coseng.RunTests;
+import com.sios.stc.coseng.run.Browsers.Browser;
+import com.sios.stc.coseng.run.Locations.Location;
+import com.sios.stc.coseng.run.Matcher.MatchBy;
+import com.sios.stc.coseng.util.Http;
+import com.sios.stc.coseng.util.Resource;
 
 /**
  * The Class CosengRunner. This is the class that each TestNG class under test
@@ -43,12 +72,76 @@ import com.paulhammant.ngwebdriver.NgWebDriver;
  */
 public class CosengRunner {
 
-    private static Map<Thread, Test>             threadTest             =
+    private static final Logger                    log                    =
+            LogManager.getLogger(RunTests.class.getName());
+    private static final String                    DIR_SCREENSHOTS        = "coseng-screenshots";
+    private static final String                    DIR_ADDITIONAL_REPORTS = "coseng-reports";
+    private static int                             startedWebDriver       = 0;
+    private static int                             stoppedWebDriver       = 0;
+    private static Map<Thread, Test>               threadTest             =
             new HashMap<Thread, Test>();
-    private static Map<Thread, WebDriverToolbox> threadWebDriverToolbox =
-            new HashMap<Thread, WebDriverToolbox>();
-    private static int                           startedWebDriver       = 0;
-    private static int                           stoppedWebDriver       = 0;
+    private static Map<Thread, WebDriver>          threadWebDriver        =
+            new HashMap<Thread, WebDriver>();
+    private static Map<Thread, Object>             threadWebDriverService =
+            new HashMap<Thread, Object>();
+    private static Map<Thread, WebDriverWait>      threadWebDriverWait    =
+            new HashMap<Thread, WebDriverWait>();
+    private static Map<Thread, Actions>            threadActions          =
+            new HashMap<Thread, Actions>();
+    private static Map<Thread, JavascriptExecutor> threadJsExecutor       =
+            new HashMap<Thread, JavascriptExecutor>();
+    private static Map<Thread, NgWebDriver>        threadNgWebDriver      =
+            new HashMap<Thread, NgWebDriver>();
+
+    /* Global collection of found URLs */
+    private static Map<String, String>      allUrlsTag    = new HashMap<String, String>();
+    private static Map<String, Set<String>> allUrlsRoutes = new HashMap<String, Set<String>>();
+    /*
+     * Non static so each extended instance is self-contained for
+     * finding/saving/checking URLs
+     */
+    private Map<String, String>      urlsTag    = new HashMap<String, String>();
+    private Map<String, Set<String>> urlsRoutes = new HashMap<String, Set<String>>();
+
+    /* Deprecated; supporting 2.0 */
+    private WebElements webElements = new WebElements();
+
+    /**
+     * Sets the selenium tools.
+     *
+     * @param webDriver
+     *            the web driver
+     * @param webDriverService
+     *            the web driver service
+     * @throws CosengException
+     *             the coseng exception
+     * @see com.sios.stc.coseng.run.WebDriverLifecycle#startWebDriver(Test)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected static synchronized void setSeleniumTools(WebDriver webDriver,
+            Object webDriverService) throws CosengException {
+        Thread thread = Thread.currentThread();
+        Test test = getThreadTest(thread);
+        if (test != null && webDriver != null) {
+            ((RemoteWebDriver) webDriver).setLogLevel(Level.FINE);
+            webDriver.manage().timeouts().implicitlyWait(test.getWebDriverTimeoutSeconds(),
+                    TimeUnit.SECONDS);
+            webDriver.manage().timeouts().pageLoadTimeout(test.getWebDriverTimeoutSeconds(),
+                    TimeUnit.SECONDS);
+            webDriver.manage().timeouts().setScriptTimeout(test.getWebDriverTimeoutSeconds(),
+                    TimeUnit.SECONDS);
+        } else {
+            throw new CosengException("Error creating selenium tools");
+        }
+        threadWebDriver.put(thread, webDriver);
+        threadWebDriverService.put(thread, webDriverService);
+        threadWebDriverWait.put(thread,
+                new WebDriverWait(webDriver, test.getWebDriverWaitTimeoutSeconds()));
+        threadActions.put(thread, new Actions(webDriver));
+        threadJsExecutor.put(thread, (JavascriptExecutor) webDriver);
+        threadNgWebDriver.put(thread, new NgWebDriver((JavascriptExecutor) webDriver));
+    }
 
     /**
      * Instantiates a new coseng runner.
@@ -59,25 +152,10 @@ public class CosengRunner {
     protected CosengRunner() {
         /*
          * Do nothing; avoids having to declare a default constructor for the
-         * TestNG test classes which would be required if instantiating the this
+         * TestNG test classes which would be required if instantiating this
          * class as it throws CosengExceptions. Reason why each test class
          * extends this class.
          */
-    }
-
-    /**
-     * Gets the test.
-     *
-     * @return the test
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getTest()
-     * @since 2.0
-     * @version.coseng
-     */
-    protected static Test getTest() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getTest();
-        }
-        return null;
     }
 
     /**
@@ -103,98 +181,68 @@ public class CosengRunner {
      *            the thread
      * @param test
      *            the test
-     * @since 2.0
+     * @since 2.1
      * @version.coseng
      */
-    protected static synchronized void setThreadTest(Thread thread, Test test) {
+    protected static synchronized void addThreadTest(Thread thread, Test test) {
         if (thread != null && test != null) {
             threadTest.put(thread, test);
         }
     }
 
     /**
-     * Gets the web driver toolbox for the current thread.
+     * Gets the test.
      *
-     * @return the web driver toolbox
+     * @return the test
      * @since 2.0
      * @version.coseng
      */
-    protected static synchronized WebDriverToolbox getWebDriverToolbox() {
-        return getWebDriverToolbox(Thread.currentThread());
+    protected static synchronized Test getTest() {
+        return getTest(null);
     }
 
     /**
-     * Gets the web driver toolbox for a given thread.
-     *
-     * @param thread
-     *            the thread
-     * @return the web driver toolbox
-     * @since 2.0
-     * @version.coseng
-     */
-    protected static synchronized WebDriverToolbox getWebDriverToolbox(Thread thread) {
-        if (threadWebDriverToolbox.containsKey(thread)) {
-            return threadWebDriverToolbox.get(thread);
-        }
-        return null;
-    }
-
-    /**
-     * Sets the web driver toolbox for a given thread.
+     * Gets the test.
      *
      * @param thread
      *            the thread
-     * @param webDriverToolbox
-     *            the web driver toolbox
-     * @since 2.0
+     * @return the test
+     * @since 2.1
      * @version.coseng
      */
-    protected static synchronized void setWebDriverToolbox(Thread thread,
-            WebDriverToolbox webDriverToolbox) {
-        if (thread != null && webDriverToolbox != null) {
-            threadWebDriverToolbox.put(thread, webDriverToolbox);
-            startedWebDriver++;
+    protected static synchronized Test getTest(Thread thread) {
+        if (thread == null) {
+            thread = Thread.currentThread();
         }
+        return getThreadTest(thread);
     }
 
     /**
-     * Checks for web driver toolbox for the current thread.
+     * Checks for web driver.
      *
      * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#hasWebDriver(Thread)
      * @since 2.0
      * @version.coseng
      */
-    protected static synchronized boolean hasWebDriverToolbox() {
-        Thread thread = Thread.currentThread();
-        return hasWebDriverToolbox(thread);
+    protected static synchronized boolean hasWebDriver() {
+        return hasWebDriver(null);
     }
 
     /**
-     * Checks for web driver toolbox for a given thread.
+     * Checks for web driver.
      *
      * @param thread
      *            the thread
      * @return true, if successful
-     * @since 2.0
+     * @since 2.1
      * @version.coseng
      */
-    protected static synchronized boolean hasWebDriverToolbox(Thread thread) {
-        if (threadWebDriverToolbox.containsKey(thread)) {
-            return true;
+    protected static synchronized boolean hasWebDriver(Thread thread) {
+        if (thread == null) {
+            thread = Thread.currentThread();
         }
-        return false;
-    }
-
-    /**
-     * Checks for web driver started.
-     *
-     * @return true, if successful
-     * @see com.sios.stc.coseng.run.WebDriverToolbox
-     * @since 2.0
-     * @version.coseng
-     */
-    protected boolean hasWebDriver() {
-        if (hasWebDriverToolbox() && getWebDriverToolbox().getWebDriver() != null) {
+        if (threadWebDriver.containsKey(thread) && threadWebDriver.get(thread) != null) {
             return true;
         }
         return false;
@@ -204,171 +252,119 @@ public class CosengRunner {
      * Gets the started web driver.
      *
      * @return the web driver
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebDriver()
+     * @see com.sios.stc.coseng.run.CosengRunner#getWebDriver(Thread)
      * @since 2.0
      * @version.coseng
      */
-    protected WebDriver getWebDriver() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getWebDriver();
+    protected static synchronized WebDriver getWebDriver() {
+        return getWebDriver(null);
+    }
+
+    /**
+     * Gets the started web driver.
+     *
+     * @param thread
+     *            the thread
+     * @return the web driver
+     * @since 2.1
+     * @version.coseng
+     */
+    protected static synchronized WebDriver getWebDriver(Thread thread) {
+        if (thread == null) {
+            thread = Thread.currentThread();
         }
-        return null;
+        return threadWebDriver.get(thread);
+    }
+
+    /**
+     * Gets the started web driver.
+     *
+     * @return the web driver
+     * @since 2.0
+     * @version.coseng
+     */
+    protected static synchronized Object getWebDriverService() {
+        return getWebDriverService(null);
+    }
+
+    /**
+     * Gets the started web driver service.
+     *
+     * @param thread
+     *            the thread
+     * @return the web driver service
+     * @since 2.1
+     * @version.coseng
+     */
+    protected static synchronized Object getWebDriverService(Thread thread) {
+        if (thread == null) {
+            thread = Thread.currentThread();
+        }
+        return threadWebDriverService.get(thread);
     }
 
     /**
      * Gets the web driver wait.
      *
      * @return the web driver wait
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebDriverWait()
      * @since 2.0
      * @version.coseng
      */
-    protected WebDriverWait getWebDriverWait() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getWebDriverWait();
-        }
-        return null;
+    protected static synchronized WebDriverWait getWebDriverWait() {
+        Thread thread = Thread.currentThread();
+        return threadWebDriverWait.get(thread);
     }
 
     /**
      * Gets the actions.
      *
      * @return the actions
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getActions()
      * @since 2.0
      * @version.coseng
      */
-    protected Actions getActions() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getActions();
-        }
-        return null;
+    protected static synchronized Actions getActions() {
+        Thread thread = Thread.currentThread();
+        return threadActions.get(thread);
     }
 
     /**
      * Gets the javascript executor.
      *
      * @return the javascript executor
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getJavascriptExecutor()
      * @since 2.0
      * @version.coseng
      */
-    protected JavascriptExecutor getJavascriptExecutor() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getJavascriptExecutor();
-        }
-        return null;
+    protected static synchronized JavascriptExecutor getJavascriptExecutor() {
+        Thread thread = Thread.currentThread();
+        return threadJsExecutor.get(thread);
     }
 
     /**
      * Gets the ng web driver.
      *
      * @return the ng web driver
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getNgWebDriver()
      * @since 2.0
      * @version.coseng
      */
-    protected NgWebDriver getNgWebDriver() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getNgWebDriver();
-        }
-        return null;
+    protected static synchronized NgWebDriver getNgWebDriver() {
+        Thread thread = Thread.currentThread();
+        return threadNgWebDriver.get(thread);
     }
 
     /**
-     * Gets the web driver util.
+     * Increment started web driver count.
      *
-     * @return the web driver util
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebDriverUtil()
-     * @see com.sios.stc.coseng.run.WebDriverUtil
      * @since 2.0
      * @version.coseng
      */
-    protected WebDriverUtil getWebDriverUtil() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getWebDriverUtil();
-        }
-        return null;
-    }
-
-    /**
-     * New web element.
-     *
-     * @return the web element
-     * @throws CosengException
-     *             the coseng exception
-     * @see com.sios.stc.coseng.run.CosengRunner#newWebElement(By)
-     * @see com.sios.stc.coseng.run.WebElements
-     * @see com.sios.stc.coseng.run.WebElement
-     * @since 2.0
-     * @version.coseng
-     */
-    protected WebElement newWebElement() throws CosengException {
-        return newWebElement(null);
-    }
-
-    /**
-     * New web element.
-     *
-     * @param by
-     *            the by
-     * @return the web element
-     * @throws CosengException
-     *             the coseng exception
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#newWebElement(By)
-     * @see com.sios.stc.coseng.run.WebElement#WebElement(WebDriverToolbox, By)
-     * @see com.sios.stc.coseng.run.WebElements
-     * @see com.sios.stc.coseng.run.WebElement
-     * @since 2.0
-     * @version.coseng
-     */
-    protected WebElement newWebElement(final By by) throws CosengException {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().newWebElement(by);
-        }
-        return null;
-    }
-
-    /**
-     * Gets the web elements.
-     *
-     * @return the web elements
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebElements()
-     * @see com.sios.stc.coseng.run.WebElements
-     * @see com.sios.stc.coseng.run.WebElement
-     * @since 2.0
-     * @version.coseng
-     */
-    protected WebElements getWebElements() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getWebElements();
-        }
-        return null;
-    }
-
-    /**
-     * Gets the web element list.
-     *
-     * @return the web element list
-     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebElementList()
-     * @see com.sios.stc.coseng.run.WebElements
-     * @see com.sios.stc.coseng.run.WebElement
-     * @since 2.0
-     * @version.coseng
-     */
-    protected List<WebElement> getWebElementList() {
-        if (hasWebDriverToolbox()) {
-            return getWebDriverToolbox().getWebElementList();
-        }
-        return null;
+    protected static synchronized void incrementStartedWebDriverCount() {
+        startedWebDriver++;
     }
 
     /**
      * Gets the started web driver count.
      *
      * @return the started web driver count
-     * @see com.sios.stc.coseng.run.CosengRunner#setWebDriverToolbox(Thread,
-     *      WebDriverToolbox)
      * @since 2.0
      * @version.coseng
      */
@@ -395,6 +391,855 @@ public class CosengRunner {
      */
     protected static synchronized int getStoppedWebDriverCount() {
         return stoppedWebDriver;
+    }
+
+    /* BEGIN - Convenience methods */
+
+    /**
+     * New web element.
+     *
+     * @return the web element
+     * @throws CosengException
+     *             the coseng exception
+     * @see com.sios.stc.coseng.run.WebElement
+     * @see com.sios.stc.coseng.run.CosengRunner#newWebElement(By)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected com.sios.stc.coseng.run.WebElement newWebElement() throws CosengException {
+        return newWebElement(null);
+    }
+
+    /**
+     * New web element.
+     *
+     * @param by
+     *            the by
+     * @return the web element
+     * @throws CosengException
+     *             the coseng exception
+     * @see com.sios.stc.coseng.run.WebElement
+     * @see org.openqa.selenium.By
+     * @since 2.1
+     * @version.coseng
+     */
+    protected com.sios.stc.coseng.run.WebElement newWebElement(By by) throws CosengException {
+        com.sios.stc.coseng.run.WebElement webElement = new com.sios.stc.coseng.run.WebElement(by);
+        webElements.add(webElement); // Deprecated; supporting 2.0
+        return webElement;
+    }
+
+    /**
+     * Web driver get.
+     *
+     * @param url
+     *            the url
+     * @see org.openqa.selenium.WebDriver#get(String)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void webDriverGet(String url) {
+        WebDriver webDriver = getWebDriver();
+        if (webDriver != null) {
+            webDriver.get(url);
+        }
+    }
+
+    /**
+     * Web driver navigate to.
+     *
+     * @param url
+     *            the url
+     * @throws CosengException
+     *             the coseng exception
+     * @see com.sios.stc.coseng.run.CosengRunner#webDriverNavigateTo(URL)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void webDriverNavigateTo(String url) throws CosengException {
+        try {
+            URL urlObj = new URL(url);
+            webDriverNavigateTo(urlObj);
+        } catch (MalformedURLException e) {
+            throw new CosengException("MalformedURLException", e);
+        }
+    }
+
+    /**
+     * Web driver navigate to.
+     *
+     * @param url
+     *            the url
+     * @see org.openqa.selenium.WebDriver#navigate()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void webDriverNavigateTo(URL url) {
+        WebDriver webDriver = getWebDriver();
+        if (webDriver != null) {
+            webDriver.navigate().to(url);
+        }
+    }
+
+    /**
+     * Gets the current url. Adjusts for Angular2 apps.
+     *
+     * @return the current url
+     * @see org.openqa.selenium.WebDriver#getCurrentUrl()
+     * @see com.paulhammant.ngwebdriver.NgWebDriver#getLocationAbsUrl()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected String getCurrentUrl() {
+        Test test = getTest();
+        WebDriver webDriver = getWebDriver();
+        NgWebDriver ngWebDriver = getNgWebDriver();
+        if (test != null && webDriver != null && ngWebDriver != null) {
+            if (test.isAngular2App()) {
+                if (Location.NODE.equals(test.getLocation())) {
+                    /* Local execution can outpace */
+                    pause(250L);
+                }
+                return ngWebDriver.getLocationAbsUrl();
+            } else {
+                return webDriver.getCurrentUrl();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Current url contains.
+     *
+     * @param route
+     *            the route
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#currentUrlMatchBy(String,
+     *      MatchBy)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean currentUrlContains(String route) {
+        return currentUrlMatchBy(route, MatchBy.CONTAIN);
+    }
+
+    /**
+     * Current url equals.
+     *
+     * @param route
+     *            the route
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#currentUrlMatchBy(String,
+     *      MatchBy)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean currentUrlEquals(String route) {
+        return currentUrlMatchBy(route, MatchBy.EQUAL);
+    }
+
+    /**
+     * Current url match by.
+     *
+     * @param route
+     *            the route
+     * @param matchBy
+     *            the match by
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#currentUrlContains(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#currentUrlEquals(String)
+     * @since 2.1
+     * @version.coseng
+     */
+    private boolean currentUrlMatchBy(String route, MatchBy matchBy) {
+        boolean matched = false;
+        String currentUrl = getCurrentUrl();
+        if (currentUrl != null) {
+            if (MatchBy.CONTAIN.equals(matchBy)) {
+                if (currentUrl.contains(route)) {
+                    matched = true;
+                }
+            } else {
+                // default matcher
+                if (currentUrl.equals(route)) {
+                    matched = true;
+                }
+            }
+        }
+        return matched;
+    }
+
+    /**
+     * Accept invalid SSL certificate. Uses web driver to click through
+     * accepting invalid certs. Note: Only available for Microsoft Internet
+     * Explorer (IE) and Edge.
+     *
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void acceptInvalidSSLCertificate() {
+        /*
+         * To accept self-signed or other SSL Certificates Should try with
+         * browser profile; this as last resort.
+         */
+        /*
+         * 2016-09-01 Doesn't work with FF 48. Can't do gimick as with IE since
+         * geckodriver will bomb before getting chance to 'drive' thru manually
+         * accepting the invalid certs. (Awaiting upstream geckodriver fix).
+         * Till then import cert into profile or add to browser.
+         */
+        Test test = getTest();
+        WebDriver webDriver = getWebDriver();
+        Actions actions = getActions();
+        if (test != null && webDriver != null && actions != null) {
+            Browser browser = test.getBrowser();
+            if (Browser.IE.equals(browser)) {
+                boolean title =
+                        webDriver.getTitle().equals("Certificate Error: Navigation Blocked");
+                int count = webDriver.findElements(By.id("overridelink")).size();
+                if (title && (count == 1)) {
+                    WebElement overrideLink = webDriver.findElement(By.id("overridelink"));
+                    if (overrideLink.isDisplayed()) {
+                        actions.moveToElement(overrideLink).click().build().perform();
+                    }
+                }
+            } else if (Browser.EDGE.equals(browser)) {
+                boolean title =
+                        webDriver.getTitle().equals("Certificate error: Navigation blocked");
+                int count = webDriver.findElements(By.id("continueLink")).size();
+                if (title && (count == 1)) {
+                    WebElement overrideLink = webDriver.findElement(By.id("continueLink"));
+                    if (overrideLink.isDisplayed()) {
+                        actions.moveToElement(overrideLink).click().build().perform();
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Save screenshot.
+     *
+     * @see com.sios.stc.coseng.run.CosengRunner#saveScreenshot(String)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void saveScreenshot() {
+        saveScreenshot(null);
+    }
+
+    /**
+     * Save screenshot. Without a name the screenshot will be saved as
+     * YYYMMddHHmmss.png. Best effort. Will warn if unable to save screenshot.
+     *
+     * @param name
+     *            the name; may not be null or empty
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void saveScreenshot(String name) {
+        Test test = getTest();
+        WebDriver webDriver = getWebDriver();
+        if (test != null && webDriver != null) {
+            if (test.isAllowScreenshots()) {
+                ArrayList<String> dirPaths = new ArrayList<String>();
+                dirPaths.add(test.getReportDirectoryFile().getAbsolutePath());
+                dirPaths.add(DIR_SCREENSHOTS);
+                dirPaths.add(test.getTestNgSuite());
+                dirPaths.add(test.getTestNgTest());
+                dirPaths.add(test.getTestNgClass());
+                dirPaths.add(test.getTestNgMethod());
+                String dirPath = StringUtils.join(dirPaths, File.separator);
+                if (name == null || name.isEmpty()) {
+                    DateFormat dateFormat = new SimpleDateFormat("YYYYMMddHHmmss");
+                    Calendar cal = Calendar.getInstance();
+                    name = dateFormat.format(cal.getTime());
+                }
+                try {
+                    /* Make directory in report directory */
+                    File dir = new File(dirPath);
+                    if (!dir.exists()) {
+                        dir.mkdirs();
+                    }
+                    /* Save the screenshot */
+                    File screenshotIn =
+                            ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.FILE);
+                    File screenshotOut = new File(dirPath + File.separator + name + ".png");
+                    FileUtils.copyFile(screenshotIn, screenshotOut);
+                } catch (Exception e) {
+                    log.warn("Save screenshot [" + name + "] unsuccessful", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Upload file.
+     *
+     * @param uploadElement
+     *            the upload element; must exist, be displayed and not have
+     *            "readonly" attribute
+     * @param fileName
+     *            the file name must not be null or empty
+     * @throws CosengException
+     * @see com.sios.stc.coseng.util.Resource#get(String)
+     * @see com.sios.stc.coseng.util.Resource#create(InputStream, File)
+     * @see com.sios.stc.coseng.run.WebDriverLifecycle#startWebDriver(Test)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void uploadFile(WebElement uploadElement, String fileName) throws CosengException {
+        Test test = getTest();
+        if (test != null && fileName != null && !fileName.isEmpty() && uploadElement != null
+                && uploadElement.isDisplayed() && uploadElement.getAttribute("readonly") == null) {
+            try {
+                InputStream fileInput = Resource.get(fileName);
+                File resourceDir = test.getResourceDirectory();
+                File resource = new File(resourceDir + File.separator + fileName);
+                Resource.create(fileInput, resource);
+                String resourcePath = resource.getAbsolutePath();
+                /*
+                 * NOTE! ((RemoteWebDriver) webDriver).setFileDetector(new
+                 * LocalFileDetector()); in
+                 * WebDriverLifecycle.startWebDriver(Test)
+                 * 
+                 * If set here instead of earlier when starting the web driver
+                 * you may get exceptions that the "path is not absolute".
+                 */
+                uploadElement.sendKeys(resourcePath);
+            } catch (CosengException e) {
+                throw new CosengException("Unable to upload file [{}]; assure file exists", e);
+            }
+        } else {
+            throw new CosengException("Unable to upload file [" + fileName
+                    + "]; fileName may not be empty, uploadElement must exist, be displayed and must not have 'readonly' attribute");
+        }
+    }
+
+    /**
+     * Pause.
+     *
+     * @see com.sios.stc.coseng.run.CosengRunner#pause(Long)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void pause() {
+        pause(null);
+    }
+
+    /**
+     * Pause. Default 1000 milliseconds.
+     *
+     * @param milliseconds
+     *            the milliseconds
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void pause(Long milliseconds) {
+        Long millis = new Long(1000);
+        if (milliseconds != null && milliseconds >= 0) {
+            millis = milliseconds;
+        }
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+        do {
+            // cpu burner
+        } while (stopWatch.getTime() < millis);
+    }
+
+    /**
+     * Find urls. Collects current URL Xpath 'href' and 'src' URLs. Adds found
+     * URL to 'all' found URLs. Waits for Angular2 apps to finish requests.
+     * Derived code.
+     * 
+     * @link http://stackoverflow.com/questions/28163618/fetching-all-href-links-from-the-page-source-using-webdriver
+     * @link http://stackoverflow.com/users/2897008/vins
+     * @link https://opensource.org/licenses/MIT
+     * @author Vins
+     * @author James B. Crocker
+     * 
+     * @see com.sios.stc.coseng.run.CosengRunner#getUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#getUrlTag(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#getUrlRoutes(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#getAllUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#getAllUrlTag(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#getAllUrlRoutes(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#saveUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#saveAllUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized void findUrls() {
+        Test test = getTest();
+        WebDriver webDriver = getWebDriver();
+        NgWebDriver ngWebDriver = getNgWebDriver();
+        if (test != null && test.isAllowFindUrls() && webDriver != null && ngWebDriver != null) {
+            if (test.isAngular2App()) {
+                ngWebDriver.waitForAngular2RequestsToFinish();
+            }
+            List<org.openqa.selenium.WebElement> urlList =
+                    webDriver.findElements(By.xpath("//*[@href or @src]"));
+            for (org.openqa.selenium.WebElement webElement : urlList) {
+                String url = webElement.getAttribute("href");
+                if (url == null) {
+                    url = webElement.getAttribute("src");
+                }
+                if (url != null && !url.isEmpty()) {
+                    /* Record url and tag */
+                    String tag = webElement.getTagName();
+                    if (tag != null && !tag.isEmpty()) {
+                        urlsTag.put(url, webElement.getTagName());
+                    }
+                    /* Record url and associated routes */
+                    Set<String> routes;
+                    String route = getCurrentUrl();
+                    if (!urlsRoutes.containsKey(url)) {
+                        routes = new HashSet<String>();
+                        routes.add(route);
+                        urlsRoutes.put(url, routes);
+                    } else {
+                        routes = urlsRoutes.get(url);
+                        routes.add(route);
+                    }
+                }
+            }
+            CosengRunner.allUrlsTag.putAll(urlsTag);
+            CosengRunner.allUrlsRoutes.putAll(urlsRoutes);
+        }
+    }
+
+    /**
+     * Gets the found urls.
+     *
+     * @return the urls
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized Set<String> getUrls() {
+        return urlsTag.keySet();
+    }
+
+    /**
+     * Gets all the found urls.
+     *
+     * @return all urls
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized Set<String> getAllUrls() {
+        return allUrlsTag.keySet();
+    }
+
+    /**
+     * Gets the url tag.
+     *
+     * @param url
+     *            the url
+     * @return the url tag
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized String getUrlTag(String url) {
+        if (urlsTag.containsKey(url)) {
+            return urlsTag.get(url);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the url tag from all urls.
+     *
+     * @param url
+     *            the url
+     * @return the url tag
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized String getAllUrlTag(String url) {
+        if (allUrlsTag.containsKey(url)) {
+            return allUrlsTag.get(url);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the url routes.
+     *
+     * @param url
+     *            the url
+     * @return the url routes
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized Set<String> getUrlRoutes(String url) {
+        Set<String> routes = new HashSet<String>();
+        if (urlsRoutes.containsKey(url)) {
+            return urlsRoutes.get(url);
+        }
+        return routes;
+    }
+
+    /**
+     * Gets routes from all urls.
+     *
+     * @param url
+     *            the url
+     * @return the all url routes
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected synchronized Set<String> getAllUrlRoutes(String url) {
+        Set<String> routes = new HashSet<String>();
+        if (allUrlsRoutes.containsKey(url)) {
+            return allUrlsRoutes.get(url);
+        }
+        return routes;
+    }
+
+    /**
+     * Save urls.
+     *
+     * @see com.sios.stc.coseng.run.CosengRunner#saveUrls(boolean)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void saveUrls() {
+        saveUrls(false);
+    }
+
+    /**
+     * Save all urls.
+     *
+     * @see com.sios.stc.coseng.run.CosengRunner#saveUrls(boolean)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void saveAllUrls() {
+        saveUrls(true);
+    }
+
+    /**
+     * Save urls.
+     *
+     * @param allUrls
+     *            either all urls or specific test's urls
+     * @see com.sios.stc.coseng.run.CosengRunner#saveUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#saveAllUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    private synchronized void saveUrls(boolean allUrls) {
+        Test test = getTest();
+        if (test != null && test.isAllowFindUrls()) {
+            String fileName = "foundUrls.txt";
+            if (allUrls) {
+                fileName = "allFoundUrls.txt";
+            }
+            ArrayList<String> dirPaths = new ArrayList<String>();
+            dirPaths.add(test.getReportDirectoryFile().getAbsolutePath());
+            dirPaths.add(DIR_ADDITIONAL_REPORTS);
+            dirPaths.add(test.getTestNgSuite());
+            dirPaths.add(test.getTestNgTest());
+            dirPaths.add(test.getTestNgClass());
+            dirPaths.add(test.getTestNgMethod());
+            String dirPath = StringUtils.join(dirPaths, File.separator);
+            File file = new File(dirPath + File.separator + fileName);
+            try {
+                /* Make directory in report directory */
+                File dir = new File(dirPath);
+                if (!dir.exists()) {
+                    dir.mkdirs();
+                }
+                /* Save the report */
+                List<String> report = new ArrayList<String>();
+                Set<String> urls = getUrls();
+                if (allUrls) {
+                    urls = getAllUrls();
+                }
+                for (String url : urls) {
+                    Integer responseCode = Http.getResponseCode(url);
+                    report.add("[" + url + "], tag [" + getAllUrlTag(url) + "], response code ["
+                            + (responseCode == null || responseCode == 0 ? "n/a" : responseCode)
+                            + "]; found in routes " + getAllUrlRoutes(url));
+                }
+                String longReport = StringUtils.join(report, System.lineSeparator());
+                InputStream stream =
+                        new ByteArrayInputStream(longReport.getBytes(StandardCharsets.UTF_8));
+                FileUtils.copyToFile(stream, file);
+            } catch (Exception e) {
+                log.warn("Save found URLs [" + file.getName() + "] unsuccessful", e);
+            }
+        }
+    }
+
+    /**
+     * Urls accessible.
+     *
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#urlsAccessible(Set, Set)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean urlsAccessible() {
+        return urlsAccessible(null, null);
+    }
+
+    /**
+     * Urls accessible.
+     *
+     * @param skipTags
+     *            the skip tags
+     * @param skipUrls
+     *            the skip urls
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#urlsAccessible(Set, Set,
+     *      boolean)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean urlsAccessible(Set<String> skipTags, Set<String> skipUrls) {
+        return urlsAccessible(skipTags, skipUrls, false);
+    }
+
+    /**
+     * All urls accessible.
+     *
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#allUrlsAccessible(Set, Set)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean allUrlsAccessible() {
+        return allUrlsAccessible(null, null);
+    }
+
+    /**
+     * All urls accessbile.
+     *
+     * @param skipTags
+     *            the skip tags
+     * @param skipUrls
+     *            the skip urls
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#urlsAccessible(Set, Set,
+     *      boolean)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean allUrlsAccessible(Set<String> skipTags, Set<String> skipUrls) {
+        return urlsAccessible(skipTags, skipUrls, true);
+    }
+
+    /**
+     * Urls accessible.
+     *
+     * @param skipTags
+     *            the skip tags
+     * @param skipUrls
+     *            the skip urls
+     * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#urlsAccessible()
+     * @see com.sios.stc.coseng.run.CosengRunner#urlsAccessible(Set, Set)
+     * @see com.sios.stc.coseng.run.CosengRunner#allUrlsAccessible()
+     * @see com.sios.stc.coseng.run.CosengRunner#allUrlsAccessible(Set, Set)
+     * @see com.sios.stc.coseng.run.CosengRunner#findUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#getAllUrls()
+     * @see com.sios.stc.coseng.run.CosengRunner#getAllUrlTag(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#getAllUrlRoutes(String)
+     * @see com.sios.stc.coseng.util.Http#isAccessible(String)
+     * @see com.sios.stc.coseng.util.Http#getUrlResponseCode(String)
+     * @since 2.1
+     * @version.coseng
+     */
+    private synchronized boolean urlsAccessible(Set<String> skipTags, Set<String> skipUrls,
+            boolean allUrls) {
+        boolean allUrlsAccessible = true;
+        Set<String> urls = getUrls();
+        if (allUrls) {
+            urls = getAllUrls();
+        }
+        for (String url : urls) {
+            boolean skip = false;
+            if (skipUrls != null && skipUrls.contains(url)) {
+                skip = true;
+            }
+            String tag = getAllUrlTag(url);
+            if (skipTags != null && skipTags.contains(tag)) {
+                skip = true;
+            }
+            if (skip) {
+                log.warn("Skipping URL [{}], tag [{}]; found on routes {}", url, tag,
+                        getAllUrlRoutes(url));
+                continue;
+            }
+            if (!Http.isAccessible(url)) {
+                Integer responseCode = Http.getResponseCode(url);
+                log.error("URL [{}], tag [{}], response code [{}]; found on routes {}", url, tag,
+                        (responseCode == null || responseCode == 0 ? "n/a" : responseCode),
+                        getAllUrlRoutes(url));
+                allUrlsAccessible = false;
+            }
+        }
+        return allUrlsAccessible;
+    }
+
+    /* Deprecated */
+
+    /**
+     * Sets the thread test association.
+     *
+     * @param thread
+     *            the thread
+     * @param test
+     *            the test
+     * @see com.sios.stc.coseng.run.CosengRunner#addThreadTest(Thread, Test)
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected static synchronized void setThreadTest(Thread thread, Test test) {
+        addThreadTest(thread, test);
+    }
+
+    /**
+     * Gets the web driver util.
+     *
+     * @return the web driver util
+     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebDriverUtil()
+     * @see com.sios.stc.coseng.run.WebDriverUtil
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected WebDriverUtil getWebDriverUtil() {
+        try {
+            return new WebDriverUtil();
+        } catch (CosengException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Gets the web driver toolbox for the current thread.
+     *
+     * @return the web driver toolbox
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected static synchronized WebDriverToolbox getWebDriverToolbox() {
+        try {
+            return new WebDriverToolbox(getTest(), getWebDriver(), getWebDriverService());
+        } catch (CosengException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Gets the web driver toolbox for a given thread.
+     *
+     * @param thread
+     *            the thread
+     * @return the web driver toolbox
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected static synchronized WebDriverToolbox getWebDriverToolbox(Thread thread) {
+        try {
+            return new WebDriverToolbox(getTest(thread), getWebDriver(thread),
+                    getWebDriverService(thread));
+        } catch (CosengException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Sets the web driver toolbox for a given thread.
+     *
+     * @param thread
+     *            the thread
+     * @param webDriverToolbox
+     *            the web driver toolbox
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected static synchronized void setWebDriverToolbox(Thread thread,
+            WebDriverToolbox webDriverToolbox) {
+        // do nothing
+    }
+
+    /**
+     * Checks for web driver toolbox for the current thread.
+     *
+     * @return true, if successful
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected static synchronized boolean hasWebDriverToolbox() {
+        return false;
+    }
+
+    /**
+     * Checks for web driver toolbox for a given thread.
+     *
+     * @param thread
+     *            the thread
+     * @return true, if successful
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected static synchronized boolean hasWebDriverToolbox(Thread thread) {
+        return false;
+    }
+
+    /**
+     * Gets the web elements.
+     *
+     * @return the web elements
+     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebElements()
+     * @see com.sios.stc.coseng.run.WebElements
+     * @see com.sios.stc.coseng.run.WebElement
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected WebElements getWebElements() {
+        return webElements;
+    }
+
+    /**
+     * Gets the web element list.
+     *
+     * @return the web element list
+     * @see com.sios.stc.coseng.run.WebDriverToolbox#getWebElementList()
+     * @see com.sios.stc.coseng.run.WebElements
+     * @see com.sios.stc.coseng.run.WebElement
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    protected List<com.sios.stc.coseng.run.WebElement> getWebElementList() {
+        return webElements.get();
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/run/Help.java
+++ b/src/main/java/com/sios/stc/coseng/run/Help.java
@@ -49,22 +49,28 @@ class Help {
         Node node = new Node();
         List<String> p = new ArrayList<String>();
         p.add("Supported Node JSON Options & Example");
+
         p.add(space(1, "reportsDirectory: (optional) String"));
         p.add(space(2, "Default [" + node.getReportsDirectory() + "]"));
+
         p.add(space(1, "resourcesTempDirectory: (optional) String"));
         p.add(space(2, "Default [" + node.getResourcesTempDirectory() + "]"));
-        p.add(space(2, "Note: platform dependent"));
-        final String PLATFORM_DEPENDS = "Note: platform dependent for location [" + Location.NODE
-                + "], ignored for location [" + Location.GRID + ")";
+        p.add(space(2, "Platform dependent"));
+        final String PLATFORM_DEPENDS = "Platform dependent for location [" + Location.NODE
+                + "]; ignored for location [" + Location.GRID + ")";
+
         p.add(space(1, "chromeDriver: (optional) String"));
         p.add(space(2, "Default [" + node.getChromeDriver() + "]"));
         p.add(space(2, PLATFORM_DEPENDS));
+
         p.add(space(1, "geckoDriver: (optional) String"));
         p.add(space(2, "Default [" + node.getGeckoDriver() + "]"));
         p.add(space(2, PLATFORM_DEPENDS));
+
         p.add(space(1, "ieDriver: (optional) String"));
         p.add(space(2, "Default [" + node.getIeDriver() + "]"));
         p.add(space(2, PLATFORM_DEPENDS));
+
         p.add(space(1, "edgeDriver: (optional) String"));
         p.add(space(2, "Default [" + node.getEdgeDriver() + "]"));
         p.add(space(2, PLATFORM_DEPENDS));
@@ -81,6 +87,11 @@ class Help {
         p.add(space(1, "gridUrl: (optional) String"));
         p.add(space(2, "Default [" + gridUrl + "]"));
         p.add(space(2, "Note: provided for undefined Test gridUrl"));
+
+        p.add(space(1, "maxTestExecutionMinutes: (optional) Integer > 0"));
+        p.add(space(2, "Default [" + node.getMaxTestExecutionMinutes() + "]"));
+        p.add(space(2, "Note: timeout for executor pool"));
+
         p.add(space(1, ""));
         p.add(getJson(node));
         return StringUtils.join(p, System.lineSeparator());
@@ -102,33 +113,59 @@ class Help {
         p.add("Supported Test JSON Options & Example");
         p.add(space(1, "name: (required) String"));
         p.add(space(2, "Default [" + test.getName() + "]"));
-        p.add(space(2, "Note: names must be unique"));
-        p.add(space(1, "verbosity: (optional) Integer 0..10"));
-        p.add(space(2, "Default [" + test.getVerbosity() + "]"));
-        p.add(space(2, "Note: TestNG logging level"));
+
         p.add(space(1, "location: (optional) Location " + Locations.get()));
         p.add(space(2, "Default [" + test.getLocation() + "]"));
+
         p.add(space(1, "platform: (optional) Platform " + Platforms.get()));
         p.add(space(2, "Default [" + test.getPlatform() + "]"));
-        p.add(space(2, "Note: operating system dependent for location [" + Location.NODE + "]"));
+        p.add(space(2, "Operating system dependent for location [" + Location.NODE + "]"));
+
         p.add(space(1, "browser: (optional) Browser " + Browsers.get()));
         p.add(space(2, "Default [" + test.getBrowser() + "]"));
-        p.add(space(2, "Note: platform dependent for location [" + Location.NODE + "]"));
+        p.add(space(2, "Platform dependent for location [" + Location.NODE + "]"));
+
         p.add(space(1, "browserVersion: (optional) String"));
         p.add(space(2, "Default [" + Browsers.BROWSER_VERSION_DEFAULT + "]"));
-        p.add(space(2, "Note: ignored for location [" + Location.NODE + "]"));
+        p.add(space(2, "Ignored for location [" + Location.NODE + "]"));
+
+        p.add(space(1, "browserWidth: (optional) Integer > 0"));
+        p.add(space(2, "Default [" + test.getBrowserWidth() + "]"));
+        p.add(space(2, "If defined, browserHeight must also be defined"));
+
+        p.add(space(1, "browserHeight: (optional) Integer > 0"));
+        p.add(space(2, "Default [" + test.getBrowserHeight() + "]"));
+        p.add(space(2, "If defined, browserWidth must also be defined"));
+
+        p.add(space(1, "browserMaximize: (optional) boolean"));
+        p.add(space(2, "Default [" + test.getBrowserMaximize() + "]"));
+        p.add(space(2, "If defined, overrides browser width and height"));
+
         p.add(space(1, "incognito: (optional) boolean"));
         p.add(space(2, "Default [" + test.isIncognito() + "]"));
+
         p.add(space(1, "acceptInvalidCerts: (optional) boolean"));
         p.add(space(2, "Default [" + test.isAcceptInvalidCerts() + "]"));
+
+        p.add(space(1, "angular2App: (optional) boolean"));
+        p.add(space(2, "Default [" + test.isAngular2App() + "]"));
+
+        p.add(space(1, "allowFindUrls: (optional) boolean"));
+        p.add(space(2, "Default [" + test.isAllowFindUrls() + "]"));
+
+        p.add(space(1, "allowScreenshots: (optional) boolean"));
+        p.add(space(2, "Default [" + test.isAllowScreenshots() + "]"));
+
         p.add(space(1, "suites: (required) list of String"));
         p.add(space(2, "Default " + test.getSuites()));
+
         p.add(space(1, "baseUrl: (optional) String"));
         p.add(space(2, "Default [" + test.getBaseUrl() + "]"));
-        final String GRIDURL_DEPENDS = "Note: (required) for location [" + Location.GRID
-                + "], (optional) String for location [" + Location.NODE + "]";
+
+        final String GRIDURL_DEPENDS1 = "(required) String for location [" + Location.GRID + "]";
+        final String GRIDURL_DEPENDS2 = "(optional) String for location [" + Location.NODE + "]";
         final String GRIDURL_NOTE =
-                "Note: if defined, overrides defined Node gridUrl, ignored for location ["
+                "If defined this overrides any defined Node JSON gridUrl; ignored for location ["
                         + Location.NODE + "]";
         String gridUrl;
         try {
@@ -140,17 +177,26 @@ class Help {
         } catch (CosengException e) {
             gridUrl = e.getCause().toString();
         }
-        p.add(space(1, "gridUrl: (required) String"));
+        p.add(space(1, "gridUrl: (optional) String"));
         p.add(space(2, "Default [" + gridUrl + "]"));
-        p.add(space(2, GRIDURL_DEPENDS));
+        p.add(space(2, GRIDURL_DEPENDS1));
+        p.add(space(2, GRIDURL_DEPENDS2));
         p.add(space(2, GRIDURL_NOTE));
+
         p.add(space(1, "oneWebDriver: (optional) boolean"));
         p.add(space(2, "Default [" + test.isOneWebDriver() + "]"));
-        p.add(space(2, "Note: all suites must have parallel=\"false\" if oneWebDriver [true]"));
+        p.add(space(2, "If oneWebDriver [true] all suites must have parallel=\"false\""));
+
         p.add(space(1, "webDriverTimeoutSeconds: (optional) Integer"));
         p.add(space(2, "Default [" + test.getWebDriverTimeoutSeconds() + "]"));
+
         p.add(space(1, "webDriverWaitTimeoutSeconds: (optional) Integer"));
         p.add(space(2, "Default [" + test.getWebDriverWaitTimeoutSeconds() + "]"));
+
+        p.add(space(1, "verbosity: (optional) Integer 0..10"));
+        p.add(space(2, "Default [" + test.getVerbosity() + "]"));
+        p.add(space(2, "TestNG logging level"));
+
         p.add(space(1, ""));
         test.setName("testHelp");
         List<String> suites = test.getSuites();

--- a/src/main/java/com/sios/stc/coseng/run/Node.java
+++ b/src/main/java/com/sios/stc/coseng/run/Node.java
@@ -41,7 +41,8 @@ import com.sios.stc.coseng.run.Browsers.Browser;
  *   "geckoDriver": "/usr/local/bin/geckodriver",
  *   "reportsDirectory": "/tmp/reports",
  *   "resourcesTempDirectory": "/tmp/coseng/resources",
- *   "gridUrl": "http://seleniumgrid.host.com:4444/wd/hub"
+ *   "gridUrl": "http://seleniumgrid.host.com:4444/wd/hub",
+ *   "maxTestExecutionMinutes": 60
  * }
  * </pre></code>
  * 
@@ -53,6 +54,7 @@ import com.sios.stc.coseng.run.Browsers.Browser;
  * <dd>gridUrl: http://localhost:4444/wd/hub</dd>
  * <dd>chromeDriver: /usr/bin/chromedriver</dd>
  * <dd>geckoDriver: /usr/bin/geckodriver</dd>
+ * <dd>maxTestExecutionMinutes: 60</dd>
  * <dt>Windows</dt>
  * <dd>reportsDirectory: "" (the current working directory)</dd>
  * <dd>resourcesTempDirectory: %USERPROFILE%\AppData\Local\Temp</dd>
@@ -61,6 +63,7 @@ import com.sios.stc.coseng.run.Browsers.Browser;
  * <dd>geckoDriver: C:\\selenium\\geckodriver.exe</dd>
  * <dd>edgeDriver: C:\\selenium\\MicrosoftWebDriver.exe</dd>
  * <dd>ieDriver: C:\\selenium\\IEDriverServer.exe</dd>
+ * <dd>maxTestExecutionMinutes: 60</dd>
  * </dl>
  *
  * @since 2.0
@@ -80,22 +83,25 @@ class Node {
             "C:\\selenium\\IEDriverServer.exe";
     private String              defaultGridUrl                     = "http://localhost:4444/wd/hub";
     private String              defaultReportsDirectory            = "coseng-reports";
+    private int                 defaultTestExecutionMinutes        = 60;
 
     @Expose
-    private final String reportsDirectory       = defaultReportsDirectory;
+    private final String reportsDirectory        = defaultReportsDirectory;
     @Expose
-    private final String resourcesTempDirectory =
+    private final String resourcesTempDirectory  =
             FileUtils.getTempDirectoryPath() + File.separator + "coseng";
     @Expose
-    private final String chromeDriver           = getDefaultWebDriver(Browser.CHROME);
+    private final String chromeDriver            = getDefaultWebDriver(Browser.CHROME);
     @Expose
-    private final String geckoDriver            = getDefaultWebDriver(Browser.FIREFOX);
+    private final String geckoDriver             = getDefaultWebDriver(Browser.FIREFOX);
     @Expose
-    private final String ieDriver               = getDefaultWebDriver(Browser.IE);
+    private final String ieDriver                = getDefaultWebDriver(Browser.IE);
     @Expose
-    private final String edgeDriver             = getDefaultWebDriver(Browser.EDGE);
+    private final String edgeDriver              = getDefaultWebDriver(Browser.EDGE);
     @Expose
-    private final String gridUrl                = defaultGridUrl;
+    private final String gridUrl                 = defaultGridUrl;
+    @Expose
+    private final int    maxTestExecutionMinutes = defaultTestExecutionMinutes;
 
     /**
      * Gets the reports directory. This is the target directory for the TestNG
@@ -253,6 +259,17 @@ class Node {
         return null;
     }
 
+    /**
+     * Gets the max test execution minutes.
+     *
+     * @return the max test execution minutes
+     * @since 2.0
+     * @version.coseng
+     */
+    protected int getMaxTestExecutionMinutes() {
+        return maxTestExecutionMinutes;
+    }
+
     /*
      * (non-Javadoc)
      * 
@@ -263,7 +280,8 @@ class Node {
         return "reportsDirectory [" + reportsDirectory + "], resourcesTempDirectory ["
                 + resourcesTempDirectory + "], chromeDriver [" + chromeDriver + "], ieDriver ["
                 + ieDriver + "], geckoDriver [" + geckoDriver + "], edgeDriver [" + edgeDriver
-                + "], gridUrl [" + gridUrl + "]";
+                + "], gridUrl [" + gridUrl + "], maxTestExecutionMinutes ["
+                + maxTestExecutionMinutes + "]";
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/run/Test.java
+++ b/src/main/java/com/sios/stc/coseng/run/Test.java
@@ -22,6 +22,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.openqa.selenium.Dimension;
 import org.openqa.selenium.Platform;
 import org.testng.xml.XmlSuite;
 
@@ -65,6 +66,12 @@ import com.sios.stc.coseng.run.Locations.Location;
  * {@value com.sios.stc.coseng.run.Browsers#BROWSER_VERSION_DEFAULT}</dd>
  * <dd>incognito: false (private/incognito for any supported browser)</dd>
  * <dd>acceptInvalidCerts: false</dd>
+ * <dd>angular2App: false</dd>
+ * <dd>allowFindUrl: false</dd>
+ * <dd>allowScreenshot: false</dd>
+ * <dd>browserWidth: null</dd>
+ * <dd>browserHeight: null</dd>
+ * <dd>browserMaximize: false</dd>
  * <dd>suites: []</dd>
  * <dd>baseUrl: null</dd>
  * <dd>gridUrl: null</dd>
@@ -80,33 +87,34 @@ public class Test {
 
     private static final int WEB_DRIVER_WAIT_TIMEOUT_SECONDS_DEFAULT     = 5;
     private static final int WEB_DRIVER_IMPLICIT_TIMEOUT_SECONDS_DEFAULT = 5;
-    private static boolean   incognitoDefault                            = false;
-    private static boolean   acceptInvalidCertsDefault                   = false;
-    private static boolean   oneWebDriverDefault                         = false;
-    private List<XmlSuite>   xmlSuites                                   =
-            new ArrayList<XmlSuite>();
-    private String           reportDirectory                             = null;
-    private File             resourceDirectory                           = null;
-    private boolean          failed                                      = false;
-    private boolean          synthetic                                   = false;
-    private File             webDriver                                   = null;
+
+    private static boolean incognitoDefault          = false;
+    private static boolean acceptInvalidCertsDefault = false;
+    private static boolean oneWebDriverDefault       = false;
+    private static boolean angular2AppDefault        = false;
+    private static boolean allowFindUrlsDefault      = false;
+    private static boolean allowScreenshotsDefault   = false;
+    private static boolean browserMaximizeDefault    = false;
+    private List<XmlSuite> xmlSuites                 = new ArrayList<XmlSuite>();
+    private String         reportDirectory           = null;
+    private File           resourceDirectory         = null;
+    private boolean        failed                    = false;
+    private boolean        synthetic                 = false;
+    private File           webDriver                 = null;
+    private String         testNgSuite               = "";
+    private String         testNgTest                = "";
+    private String         testNgClass               = "";
+    private String         testNgMethod              = "";
+    private int            testSuiteCount            = 0;
 
     @Expose
     private String             name                        = null;
-    @Expose
-    private final Integer      verbosity                   = 0;
     @Expose
     private final Location     location                    = Location.NODE;
     @Expose
     private Platform           platform                    = Platform.ANY;
     @Expose
     private Browser            browser                     = Browser.ALL;
-    @Expose
-    private String             browserVersion              = Browsers.BROWSER_VERSION_DEFAULT;
-    @Expose
-    private final boolean      incognito                   = incognitoDefault;
-    @Expose
-    private final boolean      acceptInvalidCerts          = acceptInvalidCertsDefault;
     @Expose
     private final List<String> suites                      = new ArrayList<String>();
     @Expose
@@ -121,6 +129,26 @@ public class Test {
     @Expose
     private final Integer      webDriverWaitTimeoutSeconds =
             WEB_DRIVER_IMPLICIT_TIMEOUT_SECONDS_DEFAULT;
+    @Expose
+    private String             browserVersion              = Browsers.BROWSER_VERSION_DEFAULT;
+    @Expose
+    private final boolean      incognito                   = incognitoDefault;
+    @Expose
+    private final boolean      acceptInvalidCerts          = acceptInvalidCertsDefault;
+    @Expose
+    private final boolean      angular2App                 = angular2AppDefault;
+    @Expose
+    private final boolean      allowFindUrls               = allowFindUrlsDefault;
+    @Expose
+    private final boolean      allowScreenshots            = allowScreenshotsDefault;
+    @Expose
+    private final Integer      browserWidth                = null;
+    @Expose
+    private final Integer      browserHeight               = null;
+    @Expose
+    private final boolean      browserMaximize             = browserMaximizeDefault;
+    @Expose
+    private final Integer      verbosity                   = 0;
 
     /**
      * Gets the test name.
@@ -530,6 +558,223 @@ public class Test {
         this.failed = failed;
     }
 
+    /**
+     * Gets the test ng suite.
+     *
+     * @return the test ng suite
+     * @see com.sios.stc.coseng.run.CosengListener#onStart(org.testng.ISuite)
+     * @since 2.1
+     * @version.coseng
+     */
+    public String getTestNgSuite() {
+        return this.testNgSuite;
+    }
+
+    /**
+     * Sets the test ng suite.
+     *
+     * @param suite
+     *            the new test ng suite
+     * @see com.sios.stc.coseng.run.CosengListener#onStart(org.testng.ISuite)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void setTestNgSuite(String suite) {
+        if (suite != null) {
+            this.testNgSuite = suite;
+        }
+    }
+
+    /**
+     * Gets the test ng test.
+     *
+     * @return the test ng test
+     * @see com.sios.stc.coseng.run.CosengListener#onStart(org.testng.ITestContext)
+     * @since 2.1
+     * @version.coseng
+     */
+    public String getTestNgTest() {
+        return this.testNgTest;
+    }
+
+    /**
+     * Sets the test ng test.
+     *
+     * @param test
+     *            the new test ng test
+     * @see com.sios.stc.coseng.run.CosengListener#onStart(org.testng.ITestContext)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void setTestNgTest(String test) {
+        if (test != null) {
+            this.testNgTest = test;
+        }
+    }
+
+    /**
+     * Gets the test ng class.
+     *
+     * @return the test ng class
+     * @see com.sios.stc.coseng.run.CosengListener#onBeforeClass(org.testng.ITestClass)
+     * @since 2.1
+     * @version.coseng
+     */
+    public String getTestNgClass() {
+        return this.testNgClass;
+    }
+
+    /**
+     * Sets the test ng class.
+     *
+     * @param clazz
+     *            the new test ng class
+     * @see com.sios.stc.coseng.run.CosengListener#onBeforeClass(org.testng.ITestClass)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void setTestNgClass(String clazz) {
+        if (clazz != null) {
+            this.testNgClass = clazz;
+        }
+    }
+
+    /**
+     * Gets the test ng method.
+     *
+     * @return the test ng method
+     * @see com.sios.stc.coseng.run.CosengListener#beforeInvocation(org.testng.IInvokedMethod,
+     *      org.testng.ITestResult)
+     * @since 2.1
+     * @version.coseng
+     */
+    public String getTestNgMethod() {
+        return this.testNgMethod;
+    }
+
+    /**
+     * Sets the test ng method.
+     *
+     * @param method
+     *            the new test ng method
+     * @see com.sios.stc.coseng.run.CosengListener#beforeInvocation(org.testng.IInvokedMethod,
+     *      org.testng.ITestResult)
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void setTestNgMethod(String method) {
+        if (method != null) {
+            this.testNgMethod = method;
+        }
+    }
+
+    /**
+     * Checks if is angular app.
+     *
+     * @return true, if is angular app
+     * @since 2.1
+     * @version.coseng
+     */
+    public boolean isAngular2App() {
+        return angular2App;
+    }
+
+    /**
+     * Checks if is allow find urls.
+     *
+     * @return true, if is allow find urls
+     * @since 2.1
+     * @version.coseng
+     */
+    public boolean isAllowFindUrls() {
+        return allowFindUrls;
+    }
+
+    /**
+     * Checks if is allow screenshots.
+     *
+     * @return true, if is allow screenshots
+     * @since 2.1
+     * @version.coseng
+     */
+    public boolean isAllowScreenshots() {
+        return allowScreenshots;
+    }
+
+    /**
+     * Gets the test suite count. Differs from getXmlSuite().size() in that it
+     * counts all recursively occurring <suite-file> containing <test>.
+     *
+     * @return the suite count
+     * @since 2.1
+     * @version.coseng
+     */
+    protected int getTestSuiteCount() {
+        return testSuiteCount;
+    }
+
+    /**
+     * Sets the test suite count.
+     *
+     * @param suiteCount
+     *            the new suite count
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void setTestSuiteCount(int suiteCount) {
+        this.testSuiteCount = suiteCount;
+    }
+
+    /**
+     * Gets the browser width.
+     *
+     * @return the browser width
+     * @since 2.1
+     * @version.coseng
+     */
+    protected Integer getBrowserWidth() {
+        return browserWidth;
+    }
+
+    /**
+     * Gets the browser height.
+     *
+     * @return the browser height
+     * @since 2.1
+     * @version.coseng
+     */
+    protected Integer getBrowserHeight() {
+        return browserHeight;
+    }
+
+    /**
+     * Gets the browser dimension.
+     *
+     * @return the browser dimension
+     * @since 2.1
+     * @version.coseng
+     */
+    public Dimension getBrowserDimension() {
+        Dimension browserDimension = null;
+        /* browserMaximize overrides width and height */
+        if (!browserMaximize && browserWidth != null && browserHeight != null && browserWidth > 0
+                && browserHeight > 0) {
+            browserDimension = new Dimension(browserWidth, browserHeight);
+        }
+        return browserDimension;
+    }
+
+    /**
+     * Gets the browser maximize.
+     *
+     * @return the browser maximize
+     * @since 2.1
+     * @version.coseng
+     */
+    protected boolean getBrowserMaximize() {
+        return browserMaximize;
+    }
+
     /*
      * (non-Javadoc)
      * 
@@ -540,11 +785,13 @@ public class Test {
         return "name [" + name + "], location [" + location + "], baseUrl [" + baseUrl
                 + "], gridUrl [" + gridUrl + "], platform [" + platform + "], suites " + suites
                 + ", browser [" + browser + "], browserVersion [" + browserVersion + "] incognito ["
-                + incognito + "], acceptInvalidCerts [" + acceptInvalidCerts + "], oneWebDriver ["
-                + oneWebDriver + "], verbosity [" + verbosity + "], webDriver [" + webDriver
-                + "], webDriverTimeoutSeconds [" + webDriverTimeoutSeconds
-                + "], webDriverWaitTimeoutSeconds [" + webDriverWaitTimeoutSeconds
-                + "], reportDirectory [" + reportDirectory + "]";
+                + incognito + "], acceptInvalidCerts [" + acceptInvalidCerts + "], angular2App ["
+                + angular2App + "], allowFindUrls [" + allowFindUrls + "], allowScreenshots ["
+                + allowScreenshots + "], browserWidth [" + browserWidth + "], browserHeight ["
+                + browserHeight + "], browserMaximize [" + browserMaximize + "], oneWebDriver ["
+                + oneWebDriver + "], verbosity [" + verbosity + "], webDriverTimeoutSeconds ["
+                + webDriverTimeoutSeconds + "], webDriverWaitTimeoutSeconds ["
+                + webDriverWaitTimeoutSeconds + "], reportDirectory [" + reportDirectory + "]";
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/run/Tests.java
+++ b/src/main/java/com/sios/stc/coseng/run/Tests.java
@@ -30,6 +30,8 @@ import com.google.gson.annotations.Expose;
  */
 class Tests {
 
+    private int maxTestExecutionMinutes = 0;
+
     @Expose
     private final List<Test> tests = new ArrayList<Test>();
 
@@ -202,6 +204,31 @@ class Tests {
             }
         }
         return failed;
+    }
+
+    /**
+     * Gets the max test execution minutes.
+     *
+     * @return the max test execution minutes
+     * @since 2.1
+     * @version.coseng
+     */
+    protected int getMaxTestExecutionMinutes() {
+        return this.maxTestExecutionMinutes;
+    }
+
+    /**
+     * Sets the max test execution minutes.
+     *
+     * @param maxTestExecutionMinutes
+     *            the new max test execution minutes
+     * @since 2.1
+     * @version.coseng
+     */
+    protected void setMaxTestExecutionMinutes(int maxTestExecutionMinutes) {
+        if (maxTestExecutionMinutes > 0) {
+            this.maxTestExecutionMinutes = maxTestExecutionMinutes;
+        }
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/run/WebDriverToolbox.java
+++ b/src/main/java/com/sios/stc/coseng/run/WebDriverToolbox.java
@@ -17,14 +17,11 @@
 package com.sios.stc.coseng.run;
 
 import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.remote.RemoteWebDriver;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
 import com.paulhammant.ngwebdriver.NgWebDriver;
@@ -38,6 +35,7 @@ import com.paulhammant.ngwebdriver.NgWebDriver;
  * @since 2.0
  * @version.coseng
  */
+@Deprecated
 class WebDriverToolbox {
 
     private Test               test;
@@ -49,6 +47,7 @@ class WebDriverToolbox {
     private NgWebDriver        ngWebDriver;
     private WebDriverUtil      webDriverUtil;
     private WebElements        webElements;
+    private CosengRunner       cosengRunner = new CosengRunner();
 
     /**
      * Instantiates a new web driver toolbox.
@@ -67,28 +66,15 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected WebDriverToolbox(Test test, WebDriver webDriver, Object webDriverService)
             throws CosengException {
-        if (test != null && webDriver != null) {
-            ((RemoteWebDriver) webDriver).setLogLevel(Level.FINE);
-            webDriver.manage().timeouts().implicitlyWait(test.getWebDriverTimeoutSeconds(),
-                    TimeUnit.SECONDS);
-            webDriverWait = new WebDriverWait(webDriver, test.getWebDriverWaitTimeoutSeconds());
-            actions = new Actions(webDriver);
-            jsExecutor = (JavascriptExecutor) webDriver;
-            ngWebDriver = new NgWebDriver(jsExecutor);
-        } else {
-            throw new CosengException("Error creating WebDriverToolbox");
-        }
-        this.webDriver = webDriver;
-        this.webDriverService = webDriverService;
-        this.webDriverUtil = new WebDriverUtil(test, webDriver);
-        this.webElements = new WebElements();
-        this.test = test;
+        // do nothing
     }
 
+    @Deprecated
     protected Test getTest() {
-        return test;
+        return CosengRunner.getTest();
     }
 
     /**
@@ -98,8 +84,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected WebDriver getWebDriver() {
-        return webDriver;
+        return CosengRunner.getWebDriver();
     }
 
     /**
@@ -109,8 +96,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected Object getWebDriverService() {
-        return webDriverService;
+        return CosengRunner.getWebDriverService();
     }
 
     /**
@@ -120,8 +108,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected WebDriverWait getWebDriverWait() {
-        return webDriverWait;
+        return CosengRunner.getWebDriverWait();
     }
 
     /**
@@ -131,8 +120,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected Actions getActions() {
-        return actions;
+        return CosengRunner.getActions();
     }
 
     /**
@@ -142,8 +132,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected JavascriptExecutor getJavascriptExecutor() {
-        return jsExecutor;
+        return CosengRunner.getJavascriptExecutor();
     }
 
     /**
@@ -153,8 +144,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected NgWebDriver getNgWebDriver() {
-        return ngWebDriver;
+        return CosengRunner.getNgWebDriver();
     }
 
     /**
@@ -165,8 +157,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected WebDriverUtil getWebDriverUtil() {
-        return webDriverUtil;
+        return cosengRunner.getWebDriverUtil();
     }
 
     /**
@@ -181,10 +174,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected WebElement newWebElement(final By by) throws CosengException {
-        WebElement webElement = new WebElement(this, by);
-        webElements.add(webElement);
-        return webElement;
+        return cosengRunner.newWebElement(by);
     }
 
     /**
@@ -196,8 +188,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected WebElements getWebElements() {
-        return webElements;
+        return cosengRunner.getWebElements();
     }
 
     /**
@@ -209,8 +202,9 @@ class WebDriverToolbox {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     protected List<WebElement> getWebElementList() {
-        return webElements.get();
+        return cosengRunner.getWebElementList();
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/run/WebDriverUtil.java
+++ b/src/main/java/com/sios/stc/coseng/run/WebDriverUtil.java
@@ -16,31 +16,8 @@
  */
 package com.sios.stc.coseng.run;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-
-import org.apache.commons.io.FileUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.openqa.selenium.By;
-import org.openqa.selenium.OutputType;
-import org.openqa.selenium.TakesScreenshot;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.interactions.Actions;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebDriver;
-import org.testng.Assert;
-
-import com.sios.stc.coseng.RunTests;
-import com.sios.stc.coseng.run.Browsers.Browser;
-import com.sios.stc.coseng.run.Locations.Location;
-import com.sios.stc.coseng.run.Matcher.MatchBy;
-import com.sios.stc.coseng.util.Resource;
 
 /**
  * The Class WebDriverUtil is a collection of convenience methods to perform
@@ -51,11 +28,10 @@ import com.sios.stc.coseng.util.Resource;
  * @since 2.0
  * @version.coseng
  */
+@Deprecated
 public class WebDriverUtil {
 
-    private static final Logger log = LogManager.getLogger(RunTests.class.getName());
-    private Test                test;
-    private WebDriver           webDriver;
+    private CosengRunner cosengRunner = new CosengRunner();
 
     /**
      * Instantiates a new web driver util.
@@ -66,8 +42,9 @@ public class WebDriverUtil {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public WebDriverUtil() throws CosengException {
-        this(null, null);
+        // do nothing
     }
 
     /**
@@ -82,13 +59,9 @@ public class WebDriverUtil {
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public WebDriverUtil(Test test, WebDriver webDriver) throws CosengException {
-        if (test != null && webDriver != null) {
-            this.test = test;
-            this.webDriver = webDriver;
-        } else {
-            throw new CosengException("test or webDriver null; nothing to do");
-        }
+        // do nothing
     }
 
     /**
@@ -97,11 +70,13 @@ public class WebDriverUtil {
      * @param route
      *            the route
      * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#currentUrlContains(String)
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public boolean currentUrlContains(String route) {
-        return currentUrlMatchBy(route, MatchBy.CONTAIN);
+        return cosengRunner.currentUrlContains(route);
     }
 
     /**
@@ -110,94 +85,37 @@ public class WebDriverUtil {
      * @param route
      *            the route
      * @return true, if successful
+     * @see com.sios.stc.coseng.run.CosengRunner#currentUrlEquals(String)
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public boolean currentUrlEquals(String route) {
-        return currentUrlMatchBy(route, MatchBy.EQUAL);
-    }
-
-    /**
-     * Current url match by.
-     *
-     * @param route
-     *            the route
-     * @param matchBy
-     *            the match by
-     * @return true, if successful
-     * @since 2.0
-     * @version.coseng
-     */
-    private boolean currentUrlMatchBy(String route, MatchBy matchBy) {
-        boolean matched = false;
-        if (webDriver.getCurrentUrl() != null) {
-            String currentUrl = webDriver.getCurrentUrl();
-            if (currentUrl != null) {
-                if (MatchBy.CONTAIN.equals(matchBy)) {
-                    if (currentUrl.contains(route)) {
-                        matched = true;
-                    }
-                } else {
-                    // default matcher
-                    if (currentUrl.equals(route)) {
-                        matched = true;
-                    }
-                }
-            }
-            Assert.assertTrue(matched, "Expected current URL [" + currentUrl + "] to "
-                    + matchBy.toString().toLowerCase() + " [" + route + "]");
-        }
-        return matched;
+        return cosengRunner.currentUrlEquals(route);
     }
 
     /**
      * Accept invalid SSL certificate.
      *
+     * @see com.sios.stc.coseng.run.CosengRunner#acceptInvalidSSLCertificate()
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public void acceptInvalidSSLCertificate() {
-        /*
-         * To accept self-signed or other SSL Certificates Should try with
-         * browser profile; this as last resort.
-         */
-        /*
-         * 2016-09-01 Doesn't work with FF 48. Can't do gimick as with IE since
-         * geckodriver will bomb before getting chance to 'drive' thru manually
-         * accepting the invalid certs. (Awaiting upstream geckodriver fix).
-         * Till then import cert into profile or add to browser.
-         */
-        Browser browser = test.getBrowser();
-        if (Browser.IE.equals(browser)) {
-            boolean title = webDriver.getTitle().equals("Certificate Error: Navigation Blocked");
-            int count = webDriver.findElements(By.id("overridelink")).size();
-            if (title && (count == 1)) {
-                WebElement overrideLink = webDriver.findElement(By.id("overridelink"));
-                if (overrideLink.isDisplayed()) {
-                    new Actions(webDriver).moveToElement(overrideLink).click().build().perform();
-                }
-            }
-        } else if (Browser.EDGE.equals(browser)) {
-            boolean title = webDriver.getTitle().equals("Certificate error: Navigation blocked");
-            int count = webDriver.findElements(By.id("continueLink")).size();
-            if (title && (count == 1)) {
-                WebElement overrideLink = webDriver.findElement(By.id("continueLink"));
-                if (overrideLink.isDisplayed()) {
-                    new Actions(webDriver).moveToElement(overrideLink).click().build().perform();
-                }
-            }
-        }
+        cosengRunner.acceptInvalidSSLCertificate();
     }
 
     /**
      * Save screenshot.
      *
-     * @see com.sios.stc.coseng.run.WebDriverUtil#saveScreenshot(String)
+     * @see com.sios.stc.coseng.run.CosengRunner#saveScreenshot()
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public void saveScreenshot() {
-        saveScreenshot(null);
+        cosengRunner.saveScreenshot(null);
     }
 
     /**
@@ -205,23 +123,40 @@ public class WebDriverUtil {
      *
      * @param name
      *            the name; may not be null or empty
+     * @see com.sios.stc.coseng.run.CosengRunner#saveScreenshot(String)
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public void saveScreenshot(String name) {
-        File testReportDirectory = test.getReportDirectoryFile();
-        if (name == null || name.isEmpty()) {
-            DateFormat dateFormat = new SimpleDateFormat("YYYYMMddHHmmss");
-            Calendar cal = Calendar.getInstance();
-            name = dateFormat.format(cal.getTime());
-        }
-        try {
-            File scrFile = ((TakesScreenshot) webDriver).getScreenshotAs(OutputType.FILE);
-            FileUtils.copyFile(scrFile,
-                    new File(testReportDirectory + File.separator + "screenshot-" + name + ".png"));
-        } catch (Exception e) {
-            log.warn("Save screenshot [" + name + "] unsuccessful", e);
-        }
+        cosengRunner.saveScreenshot(name);
+    }
+
+    /**
+     * Pause.
+     *
+     * @see com.sios.stc.coseng.run.WebDriverUtil#pause(Long)
+     * @see com.sios.stc.coseng.run.CosengRunner#pause()
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    public void pause() {
+        cosengRunner.pause();
+    }
+
+    /**
+     * Pause.
+     *
+     * @param milliseconds
+     *            the milliseconds
+     * @see com.sios.stc.coseng.run.CosengRunner#pause(Long)
+     * @since 2.0
+     * @version.coseng
+     */
+    @Deprecated
+    public void pause(Long milliseconds) {
+        cosengRunner.pause(milliseconds);
     }
 
     /**
@@ -233,70 +168,18 @@ public class WebDriverUtil {
      * @param fileName
      *            the file name must not be null or empty
      * @return true, if successful
-     * @see com.sios.stc.coseng.util.Resource#get(String)
-     * @see com.sios.stc.coseng.util.Resource#create(InputStream, File)
+     * @see com.sios.stc.coseng.run.CosengRunner#uploadFile(WebElement, String)
      * @since 2.0
      * @version.coseng
      */
+    @Deprecated
     public boolean uploadFile(WebElement uploadElement, String fileName) {
-        if (fileName != null && !fileName.isEmpty() && uploadElement != null
-                && uploadElement.isDisplayed() && uploadElement.getAttribute("readonly") == null) {
-            try {
-                InputStream fileInput = Resource.get(fileName);
-                Location location = test.getLocation();
-                File resourceDir = test.getResourceDirectory();
-                File resource = new File(resourceDir + File.separator + fileName);
-                Resource.create(fileInput, resource);
-                if (Location.GRID.equals(location)) {
-                    RemoteWebDriver wd = (RemoteWebDriver) webDriver;
-                    wd.setFileDetector(new LocalFileDetector());
-                    uploadElement.sendKeys(resource.getCanonicalPath());
-                } else {
-                    uploadElement.sendKeys(resource.getCanonicalPath());
-                }
-                return true;
-            } catch (CosengException | IOException e) {
-                log.error("Unable to upload file [{}]; assure file exists", fileName, e);
-            }
-        } else {
-            log.warn(
-                    "Unable to upload file [{}]; fileName may not be empty, uploadElement must exist, be displayed and must not have 'readonly' attribute",
-                    fileName);
-        }
-        return false;
-    }
-
-    /**
-     * Pause.
-     *
-     * @see com.sios.stc.coseng.run.WebDriverUtil#pause(Long)
-     * @since 2.0
-     * @version.coseng
-     */
-    public void pause() {
-        pause(null);
-    }
-
-    /**
-     * Pause.
-     *
-     * @param milliseconds
-     *            the milliseconds
-     * @since 2.0
-     * @version.coseng
-     */
-    public void pause(Long milliseconds) {
-        Long defaultMilliseconds = new Long(1000);
-        Long millis;
-        if (milliseconds == null) {
-            millis = defaultMilliseconds;
-        } else {
-            millis = milliseconds;
-        }
         try {
-            Thread.sleep(millis);
-        } catch (InterruptedException e) {
-            log.warn("Sleep thread [" + millis.toString() + "] milliseconds interrupted", e);
+            cosengRunner.uploadFile(uploadElement, fileName);
+            return true;
+        } catch (CosengException e) {
+            e.printStackTrace();
+            return false;
         }
     }
 

--- a/src/main/java/com/sios/stc/coseng/tests/demo/Ask.java
+++ b/src/main/java/com/sios/stc/coseng/tests/demo/Ask.java
@@ -19,7 +19,6 @@ package com.sios.stc.coseng.tests.demo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,32 +29,71 @@ import com.sios.stc.coseng.run.WebElement;
 
 public class Ask extends CosengRunner {
 
-    private static final String ELEMENT_SEARCHFORM = "search-box";
-    private static final String URL                = "http://www.ask.com";
-    private static final Logger log                = LogManager.getLogger(RunTests.class.getName());
+    private static final Logger log = LogManager.getLogger(RunTests.class.getName());
 
     @Test(description = "Verify connect to Ask and search")
     public void connect1() throws CosengException {
+        String url = "http://www.ask.com";
+        String searchform = "search-box";
+
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
-        WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
-                webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+                getWebDriver().hashCode(), Thread.currentThread().getId());
+
+        /*
+         * Get the url and assure on correct route. Note: Using the convenience
+         * method. Can always get the web driver with WebDriver webDriver =
+         * getWebDriver();
+         */
+        webDriverGet(url);
+        Assert.assertTrue(currentUrlContains(url));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weSearchForm = newWebElement(By.id(searchform));
+        weSearchForm.find();
+        Assert.assertTrue(weSearchForm.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("ask-connect1");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
+
     }
 
-    @Test(description = "Verify connect to Ask and search")
+    @Test(description = "Verify connect to Ask About and help button")
     public void connect2() throws CosengException {
+        String url = "http://about.ask.com";
+        String helpButton = "/html/body/section/aside/button";
+
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
-        WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
-                webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+                getWebDriver().hashCode(), Thread.currentThread().getId());
+
+        /*
+         * Get the url and assure on correct route. Note: Using the convenience
+         * method. Can always get the web driver with WebDriver webDriver =
+         * getWebDriver();
+         */
+        webDriverGet(url);
+        Assert.assertTrue(currentUrlContains(url));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weHelpButton = newWebElement(By.xpath(helpButton));
+        weHelpButton.find();
+        Assert.assertTrue(weHelpButton.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("ask-connect2");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/tests/demo/Bing.java
+++ b/src/main/java/com/sios/stc/coseng/tests/demo/Bing.java
@@ -30,32 +30,64 @@ import com.sios.stc.coseng.run.WebElement;
 
 public class Bing extends CosengRunner {
 
-    private static final String ELEMENT_SEARCHFORM = "sb_form_q";
-    private static final String URL                = "http://www.bing.com";
-    private static final Logger log                = LogManager.getLogger(RunTests.class.getName());
+    private static final Logger log = LogManager.getLogger(RunTests.class.getName());
 
     @Test(description = "Verify connect to Bing and search")
     public void connect1() throws CosengException {
+        String searchform = "sb_form_q";
+        String url = "http://www.bing.com";
+
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
         WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
                 webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+
+        /* Get the url and assure on correct route. */
+        webDriver.get(url);
+        Assert.assertTrue(currentUrlContains(url));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weSearchForm = newWebElement(By.id(searchform));
+        weSearchForm.find();
+        Assert.assertTrue(weSearchForm.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("bing-connect1");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
     }
 
-    @Test(description = "Verify connect to Bing and search")
+    @Test(description = "Verify connect to Bing Help and search")
     public void connect2() throws CosengException {
+        String searchForm = "//*[@id=\"searchquery\"]";
+        String url = "http://help.bing.microsoft.com/#apex/18/en-US/n1999/-1/en-US";
+
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
         WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
                 webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+
+        /* Get the url and assure on correct route. */
+        webDriver.get(url);
+        Assert.assertTrue(currentUrlContains(url));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weSearchForm = newWebElement(By.xpath(searchForm));
+        weSearchForm.find();
+        Assert.assertTrue(weSearchForm.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("bing-connect2");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/tests/demo/DuckDuckGo.java
+++ b/src/main/java/com/sios/stc/coseng/tests/demo/DuckDuckGo.java
@@ -19,7 +19,6 @@ package com.sios.stc.coseng.tests.demo;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.openqa.selenium.By;
-import org.openqa.selenium.WebDriver;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -30,32 +29,39 @@ import com.sios.stc.coseng.run.WebElement;
 
 public class DuckDuckGo extends CosengRunner {
 
-    private static final String ELEMENT_SEARCHFORM = "search_form_input_homepage";
-    private static final String URL                = "http://www.duckduckgo.com";
-    private static final Logger log                = LogManager.getLogger(RunTests.class.getName());
+    private static final Logger log = LogManager.getLogger(RunTests.class.getName());
 
     @Test(description = "Verify connect to DuckDuckGo and search")
     public void connect1() throws CosengException {
-        Assert.assertTrue(hasWebDriver(), "No web driver");
-        WebDriver webDriver = getWebDriver();
-        log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
-                webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
-    }
+        String searchForm = "search_form_input_homepage";
+        String url = "https://www.duckduckgo.com";
+        String redirectedUrl = "https://duckduckgo.com";
 
-    @Test(description = "Verify connect to DuckDuckGo and search")
-    public void connect2() throws CosengException {
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
-        WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
-                webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+                getWebDriver().hashCode(), Thread.currentThread().getId());
+
+        /*
+         * Get the url and assure on correct route. Note: Using the convenience
+         * method. Can always get the web driver with WebDriver webDriver =
+         * getWebDriver();
+         */
+        webDriverGet(url);
+        Assert.assertTrue(currentUrlContains(redirectedUrl));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weSearchForm = newWebElement(By.id(searchForm));
+        weSearchForm.find();
+        Assert.assertTrue(weSearchForm.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("duckDuckGo-connect1");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/tests/demo/Google.java
+++ b/src/main/java/com/sios/stc/coseng/tests/demo/Google.java
@@ -30,32 +30,65 @@ import com.sios.stc.coseng.run.WebElement;
 
 public class Google extends CosengRunner {
 
-    private static final String ELEMENT_SEARCHFORM = "searchform";
-    private static final String URL                = "http://www.google.com";
-    private static final Logger log                = LogManager.getLogger(RunTests.class.getName());
+    private static final Logger log = LogManager.getLogger(RunTests.class.getName());
 
     @Test(description = "Verify connect to Google and search")
     public void connect1() throws CosengException {
+        String searchForm = "searchform";
+        String url = "http://www.google.com";
+        String redirectedUrl = "https://www.google.com";
+
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
         WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
                 webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+
+        /* Get the url and assure on correct route. */
+        webDriver.get(url);
+        Assert.assertTrue(currentUrlContains(redirectedUrl));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weSearchForm = newWebElement(By.id(searchForm));
+        weSearchForm.find();
+        Assert.assertTrue(weSearchForm.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("google-connect1");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
     }
 
-    @Test(description = "Verify connect to Google and search")
+    @Test(description = "Verify connect to Google About and Carrers link")
     public void connect2() throws CosengException {
+        String carrers = "//*[@id=\"maia-footer-local\"]/div/ul/li[3]/a";
+        String url = "https://www.google.com/intl/en/about/";
+
+        /* Make sure a web driver for this thread */
         Assert.assertTrue(hasWebDriver(), "No web driver");
         WebDriver webDriver = getWebDriver();
         log.debug("Test [{}], web driver [{}], thread [{}]", getTest().getName(),
                 webDriver.hashCode(), Thread.currentThread().getId());
-        WebElement searchForm = newWebElement(By.id(ELEMENT_SEARCHFORM));
-        webDriver.get(URL);
-        searchForm.find();
-        Assert.assertTrue(searchForm.isDisplayed());
+
+        /* Get the url and assure on correct route. */
+        webDriver.get(url);
+        Assert.assertTrue(currentUrlContains(url));
+
+        /* Get a COSENG WebElement object, find it and assure displayed */
+        WebElement weCarrers = newWebElement(By.xpath(carrers));
+        weCarrers.find();
+        Assert.assertTrue(weCarrers.isDisplayed());
+
+        /* Take a screenshot while were here */
+        saveScreenshot("google-connect2");
+
+        /* Find and save URLs on this route */
+        findUrls();
+        saveUrls();
+        // urlsAccessible();
     }
 
 }

--- a/src/main/java/com/sios/stc/coseng/tests/demo/Urls.java
+++ b/src/main/java/com/sios/stc/coseng/tests/demo/Urls.java
@@ -1,0 +1,62 @@
+/*
+ * Concurrent Selenium TestNG (COSENG)
+ * Copyright (c) 2013-2016 SIOS Technology Corp.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sios.stc.coseng.tests.demo;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.sios.stc.coseng.RunTests;
+import com.sios.stc.coseng.run.CosengException;
+import com.sios.stc.coseng.run.CosengRunner;
+
+public class Urls extends CosengRunner {
+
+    private static final Logger log = LogManager.getLogger(RunTests.class.getName());
+
+    @Test(description = "All URLs Accessible")
+    public void accessible() throws CosengException {
+
+        /* Make sure a web driver for this thread */
+        Assert.assertTrue(hasWebDriver(), "No web driver");
+
+        /* URL Tags to skip */
+        Set<String> skipTags = new HashSet<String>();
+        skipTags.add("ng-include");
+
+        /* URL to skip */
+        Set<String> skipUrls = new HashSet<String>();
+        skipUrls.add("http://host/path");
+        skipUrls.add("mailto:support@host");
+
+        /* Check all found links accessible */
+        saveAllUrls();
+        boolean allUrlsAccessible = true;
+        // allUrlsAccessible = allUrlsAccessible(skipTags, skipUrls);
+        // Assert.assertTrue(allUrlsAccessible, "all URLs not accessible; check
+        // logs");
+        Assert.assertTrue(allUrlsAccessible,
+                "All URLs accessible IGNORED FOR DEMO; to enable uncomment in Urls.java");
+        log.warn(
+                "NOTE! *not* checking allUrlsAccessible(); would 'HEAD' url check ~300 external 'href' and 'src' elements. Uncomment line 53 to see results");
+    }
+
+}

--- a/src/main/java/com/sios/stc/coseng/util/Http.java
+++ b/src/main/java/com/sios/stc/coseng/util/Http.java
@@ -1,0 +1,177 @@
+/*
+ * Concurrent Selenium TestNG (COSENG)
+ * Copyright (c) 2013-2016 SIOS Technology Corp.  All rights reserved.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sios.stc.coseng.util;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.time.StopWatch;
+
+/**
+ * The Class Http offers conveniences to discern state of Http resrouces.
+ *
+ * @since 2.1
+ * @version.coseng
+ */
+public class Http {
+
+    private static final String         sysPropUserAgent     = "http.agent";
+    private static final String         requestMethodDefault = "HEAD";
+    private static final String         userAgentNew         =
+            "Mozilla/5.0 (X11; Linux x86_64; rv:49.0) Gecko/20100101 Firefox/49.0";
+    private static int                  millisTimeoutDefault = 3000;
+    private static Map<String, Integer> urlsResponseCode     = new HashMap<String, Integer>();
+
+    /**
+     * Checks if http url is accessible.
+     *
+     * @param url
+     *            the url
+     * @return true, if is accessible
+     * @see com.sios.stc.coseng.util.Http#isAccessible(String, Integer)
+     * @since 2.1
+     * @version.coseng
+     */
+    public static boolean isAccessible(String url) {
+        return isAccessible(url, null);
+    }
+
+    /**
+     * Checks if http url is accessible.
+     *
+     * @param url
+     *            the url
+     * @param millisTimeout
+     *            the millisecond timeout
+     * @return true, if is accessible
+     * @see com.sios.stc.coseng.util.Http#connect(String, Integer, String,
+     *      boolean)
+     * @see com.sios.stc.coseng.util.Http#accessibleResponseCode(int)
+     * @since 2.1
+     * @version.coseng
+     */
+    public static boolean isAccessible(String url, Integer millisTimeout) {
+        int responseCode = connect(url, millisTimeout, null, false);
+        boolean isAccessible = false;
+        /* Any 200 level through 300 level identified as success */
+        if (accessibleResponseCode(responseCode)) {
+            isAccessible = true;
+        } else {
+            /* Attempt again with modified user agent */
+            responseCode = connect(url, millisTimeout, null, true);
+            if (accessibleResponseCode(responseCode)) {
+                isAccessible = true;
+            }
+        }
+        urlsResponseCode.put(url, responseCode);
+        return isAccessible;
+    }
+
+    /**
+     * Accessible response code. Response code >= 200 and <= 399 is considered
+     * accessible.
+     *
+     * @param responseCode
+     *            the status code
+     * @return true, if successful
+     * @see com.sios.stc.coseng.util.Http#isAccessible(String, Integer)
+     * @since 2.1
+     * @version.coseng
+     */
+    private static boolean accessibleResponseCode(int responseCode) {
+        if (responseCode >= 200 && responseCode <= 399) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Gets the url response code.
+     *
+     * @param url
+     *            the url
+     * @return the url response code
+     * @since 2.1
+     * @version.coseng
+     */
+    public static Integer getResponseCode(String url) {
+        return urlsResponseCode.get(url);
+    }
+
+    /**
+     * Connect. Accepts invalid SSL certs. Derived code.
+     * 
+     * @link http://stackoverflow.com/questions/13778635/checking-status-of-website-in-java
+     * @link http://stackexchange.com/users/347553/bhavik-ambani
+     * @link https://opensource.org/licenses/MIT
+     * @author Bhavik Ambani
+     * @author James B. Crocker
+     *
+     * @param url
+     *            the url
+     * @param millisTimeout
+     *            the millis timeout
+     * @return the int
+     * @see com.sios.stc.coseng.util.Http#isAccessible(String, Integer)
+     * @since 2.1
+     * @version.coseng
+     */
+    private static int connect(String url, Integer millisTimeout, String requestMethod,
+            boolean changeUserAgent) {
+        if (url != null && !url.isEmpty()) {
+            String userAgentOriginal = System.getProperty(sysPropUserAgent);
+            if (millisTimeout == null || millisTimeout <= 0) {
+                millisTimeout = millisTimeoutDefault;
+            }
+            if (requestMethod == null || requestMethod.isEmpty()) {
+                requestMethod = requestMethodDefault;
+            }
+            /* Fake out the user agent when asked */
+            if (changeUserAgent) {
+                System.setProperty(sysPropUserAgent, userAgentNew);
+            }
+            StopWatch stopWatch = new StopWatch();
+            stopWatch.start();
+            /* Accept any/all certs */
+            SSLUtilities.trustAllHostnames();
+            SSLUtilities.trustAllHttpsCertificates();
+            do {
+                try {
+                    HttpURLConnection connection =
+                            (HttpURLConnection) new URL(url).openConnection();
+                    connection.setConnectTimeout(millisTimeout);
+                    connection.setReadTimeout(millisTimeout);
+                    connection.setRequestMethod(requestMethod);
+                    int responseCode = connection.getResponseCode();
+                    /* Change back to original user agent if changed */
+                    if (changeUserAgent && userAgentOriginal != null) {
+                        System.setProperty(sysPropUserAgent, userAgentOriginal);
+                    }
+                    return responseCode;
+                } catch (IOException | ClassCastException e) {
+                    // do nothing; will be 0
+                }
+            } while (stopWatch.getTime() < millisTimeout);
+            stopWatch.stop();
+        }
+        return 0;
+    }
+
+}

--- a/src/main/java/com/sios/stc/coseng/util/Resource.java
+++ b/src/main/java/com/sios/stc/coseng/util/Resource.java
@@ -21,6 +21,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URL;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
@@ -56,6 +57,30 @@ public class Resource {
             throw new CosengException("Can't get name for the resource [" + resource + "]");
         }
         throw new CosengException("Can't get name for null or empty resource");
+    }
+
+    /**
+     * Gets the relative path.
+     *
+     * @param resource
+     *            the resource
+     * @return the relative path
+     * @throws CosengException
+     *             the coseng exception
+     * @since 2.1
+     * @version.coseng
+     */
+    public static String getRelativePath(String resource) throws CosengException {
+        if (resource != null && !resource.isEmpty()) {
+            /* Removes leading file separator */
+            String path = FilenameUtils.getPath(resource);
+            if (path != null && !path.isEmpty()) {
+                return path;
+            }
+            throw new CosengException(
+                    "Can't get relative path for the resource [" + resource + "]");
+        }
+        throw new CosengException("Can't get relative path for null or empty resource");
     }
 
     /**
@@ -98,6 +123,13 @@ public class Resource {
      */
     public static InputStream get(String resource) throws CosengException {
         if (resource != null && !resource.isEmpty()) {
+            // check if URL
+            try {
+                URL url = new URL(resource);
+                return url.openStream();
+            } catch (IOException e) {
+                // wasn't a url; keep processing
+            }
             InputStream input = null;
             // check filesystem
             File file = new File(resource);

--- a/src/main/java/com/sios/stc/coseng/util/SSLUtilities.java
+++ b/src/main/java/com/sios/stc/coseng/util/SSLUtilities.java
@@ -1,0 +1,317 @@
+/*
+ * This work is licensed under the Creative Commons Attribution-ShareAlike 3.0 Unported License.
+ * To view a copy of this license, visit http://creativecommons.org/licenses/by-sa/3.0/ or
+ * send a letter to Creative Commons, PO Box 1866, Mountain View, CA 94042, USA.
+ */
+package com.sios.stc.coseng.util;
+
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.security.cert.X509Certificate;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+/**
+ * This class provide various static methods that relax X509 certificate and
+ * hostname verification while using the SSL over the HTTP protocol. call:
+ * SSLUtilities.trustAllHostnames() to turn off the default hostname
+ * verification on HTTPS connection; SSLUtilities.trustAllHttpsCertificates() to
+ * turn off the default certificate validation on HTTPS connection.
+ * 
+ * @link http://en.wikibooks.org/wiki/WebObjects/Web_Services/How_to_Trust_Any_SSL_Certificate
+ * @author Francis Labrie
+ */
+public final class SSLUtilities {
+
+    /**
+     * Hostname verifier for the Sun's deprecated API.
+     *
+     * @deprecated see {@link #_hostnameVerifier}.
+     */
+    @SuppressWarnings("restriction")
+    private static com.sun.net.ssl.HostnameVerifier __hostnameVerifier;
+    /**
+     * Thrust managers for the Sun's deprecated API.
+     *
+     * @deprecated see {@link #_trustManagers}.
+     */
+    @SuppressWarnings("restriction")
+    private static com.sun.net.ssl.TrustManager[]   __trustManagers;
+    /**
+     * Hostname verifier.
+     */
+    private static HostnameVerifier                 _hostnameVerifier;
+    /**
+     * Thrust managers.
+     */
+    private static TrustManager[]                   _trustManagers;
+
+    /**
+     * Set the default Hostname Verifier to an instance of a fake class that
+     * trust all hostnames. This method uses the old deprecated API from the
+     * com.sun.ssl package.
+     *
+     * @deprecated see {@link #_trustAllHostnames()}.
+     */
+    @SuppressWarnings("restriction")
+    private static void __trustAllHostnames() {
+        // Create a trust manager that does not validate certificate chains
+        if (__hostnameVerifier == null) {
+            __hostnameVerifier = new _FakeHostnameVerifier();
+        } // if
+          // Install the all-trusting host name verifier
+        com.sun.net.ssl.HttpsURLConnection.setDefaultHostnameVerifier(__hostnameVerifier);
+    } // __trustAllHttpsCertificates
+
+    /**
+     * Set the default X509 Trust Manager to an instance of a fake class that
+     * trust all certificates, even the self-signed ones. This method uses the
+     * old deprecated API from the com.sun.ssl package.
+     *
+     * @deprecated see {@link #_trustAllHttpsCertificates()}.
+     */
+    @SuppressWarnings("restriction")
+    private static void __trustAllHttpsCertificates() {
+        com.sun.net.ssl.SSLContext context;
+
+        // Create a trust manager that does not validate certificate chains
+        if (__trustManagers == null) {
+            __trustManagers = new com.sun.net.ssl.TrustManager[] { new _FakeX509TrustManager() };
+        } // if
+          // Install the all-trusting trust manager
+        try {
+            context = com.sun.net.ssl.SSLContext.getInstance("SSL");
+            context.init(null, __trustManagers, new SecureRandom());
+        } catch (GeneralSecurityException gse) {
+            throw new IllegalStateException(gse.getMessage());
+        } // catch
+        com.sun.net.ssl.HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+    } // __trustAllHttpsCertificates
+
+    /**
+     * Return true if the protocol handler property java. protocol.handler.pkgs
+     * is set to the Sun's com.sun.net.ssl. internal.www.protocol deprecated
+     * one, false otherwise.
+     *
+     * @return true if the protocol handler property is set to the Sun's
+     *         deprecated one, false otherwise.
+     */
+    private static boolean isDeprecatedSSLProtocol() {
+        return ("com.sun.net.ssl.internal.www.protocol"
+                .equals(System.getProperty("java.protocol.handler.pkgs")));
+    } // isDeprecatedSSLProtocol
+
+    /**
+     * Set the default Hostname Verifier to an instance of a fake class that
+     * trust all hostnames.
+     */
+    private static void _trustAllHostnames() {
+        // Create a trust manager that does not validate certificate chains
+        if (_hostnameVerifier == null) {
+            _hostnameVerifier = new FakeHostnameVerifier();
+        } // if
+          // Install the all-trusting host name verifier:
+        HttpsURLConnection.setDefaultHostnameVerifier(_hostnameVerifier);
+    } // _trustAllHttpsCertificates
+
+    /**
+     * Set the default X509 Trust Manager to an instance of a fake class that
+     * trust all certificates, even the self-signed ones.
+     */
+    private static void _trustAllHttpsCertificates() {
+        SSLContext context;
+
+        // Create a trust manager that does not validate certificate chains
+        if (_trustManagers == null) {
+            _trustManagers = new TrustManager[] { new FakeX509TrustManager() };
+        } // if
+          // Install the all-trusting trust manager:
+        try {
+            context = SSLContext.getInstance("SSL");
+            context.init(null, _trustManagers, new SecureRandom());
+        } catch (GeneralSecurityException gse) {
+            throw new IllegalStateException(gse.getMessage());
+        } // catch
+        HttpsURLConnection.setDefaultSSLSocketFactory(context.getSocketFactory());
+    } // _trustAllHttpsCertificates
+
+    /**
+     * Set the default Hostname Verifier to an instance of a fake class that
+     * trust all hostnames.
+     */
+    public static void trustAllHostnames() {
+        // Is the deprecated protocol setted?
+        if (isDeprecatedSSLProtocol()) {
+            __trustAllHostnames();
+        } else {
+            _trustAllHostnames();
+        } // else
+    } // trustAllHostnames
+
+    /**
+     * Set the default X509 Trust Manager to an instance of a fake class that
+     * trust all certificates, even the self-signed ones.
+     */
+    public static void trustAllHttpsCertificates() {
+        // Is the deprecated protocol setted?
+        if (isDeprecatedSSLProtocol()) {
+            __trustAllHttpsCertificates();
+        } else {
+            _trustAllHttpsCertificates();
+        } // else
+    } // trustAllHttpsCertificates
+
+    /**
+     * This class implements a fake hostname verificator, trusting any host
+     * name. This class uses the old deprecated API from the com.sun. ssl
+     * package.
+     *
+     * @author Francis Labrie
+     *
+     * @deprecated see {@link SSLUtilities.FakeHostnameVerifier}.
+     */
+    @SuppressWarnings("restriction")
+    public static class _FakeHostnameVerifier implements com.sun.net.ssl.HostnameVerifier {
+
+        /**
+         * Always return true, indicating that the host name is an acceptable
+         * match with the server's authentication scheme.
+         *
+         * @param hostname
+         *            the host name.
+         * @param session
+         *            the SSL session used on the connection to host.
+         * @return the true boolean value indicating the host name is trusted.
+         */
+        public boolean verify(String hostname, String session) {
+            return (true);
+        } // verify
+    } // _FakeHostnameVerifier
+
+    /**
+     * This class allow any X509 certificates to be used to authenticate the
+     * remote side of a secure socket, including self-signed certificates. This
+     * class uses the old deprecated API from the com.sun.ssl package.
+     *
+     * @author Francis Labrie
+     *
+     * @deprecated see {@link SSLUtilities.FakeX509TrustManager}.
+     */
+    @SuppressWarnings("restriction")
+    public static class _FakeX509TrustManager implements com.sun.net.ssl.X509TrustManager {
+
+        /**
+         * Empty array of certificate authority certificates.
+         */
+        private static final X509Certificate[] _AcceptedIssuers = new X509Certificate[] {};
+
+        /**
+         * Always return true, trusting for client SSL chain peer certificate
+         * chain.
+         *
+         * @param chain
+         *            the peer certificate chain.
+         * @return the true boolean value indicating the chain is trusted.
+         */
+        public boolean isClientTrusted(X509Certificate[] chain) {
+            return (true);
+        } // checkClientTrusted
+
+        /**
+         * Always return true, trusting for server SSL chain peer certificate
+         * chain.
+         *
+         * @param chain
+         *            the peer certificate chain.
+         * @return the true boolean value indicating the chain is trusted.
+         */
+        public boolean isServerTrusted(X509Certificate[] chain) {
+            return (true);
+        } // checkServerTrusted
+
+        /**
+         * Return an empty array of certificate authority certificates which are
+         * trusted for authenticating peers.
+         *
+         * @return a empty array of issuer certificates.
+         */
+        public X509Certificate[] getAcceptedIssuers() {
+            return (_AcceptedIssuers);
+        } // getAcceptedIssuers
+    } // _FakeX509TrustManager
+
+    /**
+     * This class implements a fake hostname verificator, trusting any host
+     * name.
+     *
+     * @author Francis Labrie
+     */
+    public static class FakeHostnameVerifier implements HostnameVerifier {
+
+        /**
+         * Always return true, indicating that the host name is an acceptable
+         * match with the server's authentication scheme.
+         *
+         * @param hostname
+         *            the host name.
+         * @param session
+         *            the SSL session used on the connection to host.
+         * @return the true boolean value indicating the host name is trusted.
+         */
+        public boolean verify(String hostname, javax.net.ssl.SSLSession session) {
+            return (true);
+        } // verify
+    } // FakeHostnameVerifier
+
+    /**
+     * This class allow any X509 certificates to be used to authenticate the
+     * remote side of a secure socket, including self-signed certificates.
+     *
+     * @author Francis Labrie
+     */
+    public static class FakeX509TrustManager implements X509TrustManager {
+
+        /**
+         * Empty array of certificate authority certificates.
+         */
+        private static final X509Certificate[] _AcceptedIssuers = new X509Certificate[] {};
+
+        /**
+         * Always trust for client SSL chain peer certificate chain with any
+         * authType authentication types.
+         *
+         * @param chain
+         *            the peer certificate chain.
+         * @param authType
+         *            the authentication type based on the client certificate.
+         */
+        public void checkClientTrusted(X509Certificate[] chain, String authType) {
+        } // checkClientTrusted
+
+        /**
+         * Always trust for server SSL chain peer certificate chain with any
+         * authType exchange algorithm types.
+         *
+         * @param chain
+         *            the peer certificate chain.
+         * @param authType
+         *            the key exchange algorithm used.
+         */
+        public void checkServerTrusted(X509Certificate[] chain, String authType) {
+        } // checkServerTrusted
+
+        /**
+         * Return an empty array of certificate authority certificates which are
+         * trusted for authenticating peers.
+         *
+         * @return a empty array of issuer certificates.
+         */
+        public X509Certificate[] getAcceptedIssuers() {
+            return (_AcceptedIssuers);
+        } // getAcceptedIssuers
+    } // FakeX509TrustManager
+} // SSLUtilities

--- a/src/main/resources/coseng/suites/demo/classes.xml
+++ b/src/main/resources/coseng/suites/demo/classes.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="ParallelClasses" preserve-order="true" parallel="classes">
-  <test name="TestAsk_DuckDuckGo">
+  <test name="Google_Bing_DuckDuckGo_connect2">
     <classes>
-      <class name="com.sios.stc.coseng.tests.demo.Ask">
+      <class name="com.sios.stc.coseng.tests.demo.Google">
         <methods>
           <include name="connect2" />
         </methods>
       </class>
-      <class name="com.sios.stc.coseng.tests.demo.DuckDuckGo">
+      <class name="com.sios.stc.coseng.tests.demo.Bing">
         <methods>
           <include name="connect2" />
         </methods>

--- a/src/main/resources/coseng/suites/demo/methods.xml
+++ b/src/main/resources/coseng/suites/demo/methods.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="ParallelMethods" preserve-order="true" parallel="methods">
-  <test name="TestGoogle">
+  <test name="Ask_connect1_2">
     <classes>
-      <class name="com.sios.stc.coseng.tests.demo.Google">
+      <class name="com.sios.stc.coseng.tests.demo.Ask">
         <methods>
           <include name="connect1" />
           <include name="connect2" />

--- a/src/main/resources/coseng/suites/demo/oneWebDriver.xml
+++ b/src/main/resources/coseng/suites/demo/oneWebDriver.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="OneWebDriver" preserve-order="true">
-  <test name="TestGoogle_Bing">
+<suite name="OneWebDriver" preserve-order="true" parallel="false">
+  <test name="Test Google_Bing">
     <classes>
       <class name="com.sios.stc.coseng.tests.demo.Google">
         <methods>
@@ -15,7 +15,7 @@
       </class>
     </classes>
   </test>
-  <test name="TestDuckDuckGo_Ask">
+  <test name="Test DuckDuckGo_Ask">
     <classes>
       <class name="com.sios.stc.coseng.tests.demo.DuckDuckGo">
         <methods>

--- a/src/main/resources/coseng/suites/demo/suite-files.xml
+++ b/src/main/resources/coseng/suites/demo/suite-files.xml
@@ -5,5 +5,6 @@
     <suite-file path="coseng/suites/demo/tests.xml"></suite-file>
     <suite-file path="coseng/suites/demo/classes.xml"></suite-file>
     <suite-file path="coseng/suites/demo/methods.xml"></suite-file>
+    <suite-file path="coseng/suites/demo/urls.xml"></suite-file>
   </suite-files>
 </suite>

--- a/src/main/resources/coseng/suites/demo/tests.xml
+++ b/src/main/resources/coseng/suites/demo/tests.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" standalone="no"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="ParallelTests" preserve-order="true" parallel="tests">
-  <test name="TestGoogle">
+  <test name="Google_connect1">
     <classes>
       <class name="com.sios.stc.coseng.tests.demo.Google">
         <methods>
@@ -10,9 +10,18 @@
       </class>
     </classes>
   </test>
-  <test name="TestBing">
+  <test name="Bing_connect1">
     <classes>
       <class name="com.sios.stc.coseng.tests.demo.Bing">
+        <methods>
+          <include name="connect1" />
+        </methods>
+      </class>
+    </classes>
+  </test>
+  <test name="DuckDuckGo_connect1">
+    <classes>
+      <class name="com.sios.stc.coseng.tests.demo.DuckDuckGo">
         <methods>
           <include name="connect1" />
         </methods>

--- a/src/main/resources/coseng/suites/demo/urls.xml
+++ b/src/main/resources/coseng/suites/demo/urls.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="All URLs Accessible Suite" preserve-order="true" parallel="false">
+  <test name="All URLs Accessible">
+    <classes>
+      <class name="com.sios.stc.coseng.tests.demo.Urls">
+        <methods>
+          <include name="accessible" />
+        </methods>
+      </class>
+    </classes>
+  </test>
+</suite>

--- a/src/main/resources/coseng/tests/demo/multiple-suites.json
+++ b/src/main/resources/coseng/tests/demo/multiple-suites.json
@@ -5,6 +5,8 @@
             "location": "node",
             "browser": "all",
             "oneWebDriver": false,
+            "allowFindUrls": false,
+            "allowScreenshots": false,
             "suites": [
                 "coseng/suites/demo/tests.xml",
                 "coseng/suites/demo/classes.xml",

--- a/src/main/resources/coseng/tests/demo/oneWebDriver.json
+++ b/src/main/resources/coseng/tests/demo/oneWebDriver.json
@@ -5,6 +5,8 @@
             "location": "node",
             "browser": "all",
             "oneWebDriver": true,
+            "allowFindUrls": true,
+            "allowScreenshots": true,
             "suites": [
                 "coseng/suites/demo/oneWebDriver.xml"
             ]

--- a/src/main/resources/coseng/tests/demo/single-suite.json
+++ b/src/main/resources/coseng/tests/demo/single-suite.json
@@ -5,6 +5,8 @@
             "location": "node",
             "browser": "all",
             "oneWebDriver": false,
+            "allowFindUrls": true,
+            "allowScreenshots": true,
             "suites": [
                 "coseng/suites/demo/methods.xml"
             ]

--- a/src/main/resources/coseng/tests/demo/suite-files.json
+++ b/src/main/resources/coseng/tests/demo/suite-files.json
@@ -5,6 +5,10 @@
             "location": "node",
             "browser": "all",
             "oneWebDriver": false,
+            "allowFindUrls": false,
+            "allowScreenshots": true,
+            "webDriverTimeoutSeconds": 300,
+            "webDriverWaitTimeoutSeconds": 300,
             "suites": [
                 "coseng/suites/demo/suite-files.xml"
             ]

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,10 +2,10 @@
 <Configuration>
   <Appenders>
     <File name="File" fileName="coseng.log">
-      <PatternLayout pattern="%d{DATE} %highlight{%-5level} %logger{15} [%t]; %msg%n" />
+      <PatternLayout pattern="%d{DATE} %highlight{%-5level}: [%t] [%l]; %msg%n" />
     </File>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%highlight{%-5level}: [%t]; %msg%n" />
+      <PatternLayout pattern="%highlight{%-5level}: [%t] [%l]; %msg%n" />
     </Console>
   </Appenders>
   <Loggers>


### PR DESCRIPTION
… web driver management for suites of suite-files of suite-files
- Had fixed test execution limit of 5 minutes. Added configurable maxExecutionTimeMinutes
- Added configurable setting for browser dimensions or maximize during web driver start
- Added finding of href/src urls on a page, checking accessible and saving a report on found links and status (accepts invalid certs)
- Added elapsed time counters for individual and total test times
- Removed thread sleep for pause and just made a cpu burner instead of confusing thread management
- Refactor demo tests to be a bit more distinct in execution; included an example of the find and save url features (actual checks for accessible are commented out for demoer to enable)
- Refactor screenshot save paths
- Refactor temp paths for test xml to allow better flexibility in test naming
- Refactor TestNG report path naming for clearer delineation of test runs
- Handle web driver management for suites of suite-files (of suite-files (of suite-files (of suite-files)))
- Add explicit and configurable denotation of Angular2 apps
- Deprecated WebDriverUtil and WebDriverToolbox. Unnecessary extra call to access convenience methods that could be served directly from CosengRunner